### PR TITLE
Update stats after the bot equips items, so they'll correctly get the items' stats

### DIFF
--- a/playerbot/PlayerbotFactory.cpp
+++ b/playerbot/PlayerbotFactory.cpp
@@ -1217,6 +1217,10 @@ void PlayerbotFactory::InitEquipment(bool incremental)
             continue;
         }
     }
+
+    // Update stats here so the bots will benefit from the new equipped items' stats
+    bot->InitStatsForLevel(true);
+    bot->UpdateAllStats();
 }
 
 bool PlayerbotFactory::IsDesiredReplacement(Item* item)


### PR DESCRIPTION
There's a bug with the random bots: they don't get stats from the items they have equipped.
This means that a level 60 warrior in a mix of epic and superior gear will still have ~2.5k hp, the same he'd have if naked.

To fix it I copied the code from PlayerbotFactory::InitImmersive() to PlayerbotFactory::InitEquipment().

Example before this fix:

![WoWScrnShot_022122_201144](https://user-images.githubusercontent.com/99603810/155018009-8530781a-8ca3-4524-9e25-7cc4e9423cec.jpg)

After:

![WoWScrnShot_022122_201414](https://user-images.githubusercontent.com/99603810/155018024-4c57d34e-ccd5-4123-a83c-08ce6744945e.jpg)