### PR TITLE
Allowing bot to talk in config DBCLocale channel

### DIFF
--- a/playerbot/PlayerbotMgr.cpp
+++ b/playerbot/PlayerbotMgr.cpp
@@ -354,9 +354,14 @@ void PlayerbotHolder::OnBotLogin(Player * const bot)
 #endif
     }
     // join standard channels
+    int32 locale = sConfig.GetIntDefault("DBC.Locale", 0 /*LocaleConstant::LOCALE_enUS*/); // bot->GetSession()->GetSessionDbcLocale();
+    // -- In case we're using auto detect on config file
+    if (locale == 255)
+        locale = static_cast<int32>(LocaleConstant::LOCALE_enUS);
+    
     AreaTableEntry const* current_zone = GetAreaEntryByAreaID(sTerrainMgr.GetAreaId(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ()));
     ChannelMgr* cMgr = channelMgr(bot->GetTeam());
-    std::string current_zone_name = current_zone ? current_zone->area_name[0] : "";
+    std::string current_zone_name = current_zone ? current_zone->area_name[locale] : "";
 
     if (current_zone && cMgr)
     {
@@ -379,9 +384,8 @@ void PlayerbotHolder::OnBotLogin(Player * const bot)
             Channel* new_channel = nullptr;
             if (isLfg)
             {
-                string lfgChannelName = channel->pattern[0];
 #ifndef MANGOSBOT_ZERO
-                new_channel = cMgr->GetJoinChannel("LookingForGroup", channel->ChannelID);
+                new_channel = cMgr->GetJoinChannel(channel->pattern[locale], channel->ChannelID);
 #else
                 new_channel = cMgr->GetJoinChannel("LookingForGroup");
 #endif
@@ -389,7 +393,7 @@ void PlayerbotHolder::OnBotLogin(Player * const bot)
             else
             {
                 char new_channel_name_buf[100];
-                snprintf(new_channel_name_buf, 100, channel->pattern[0], current_zone_name.c_str());
+                snprintf(new_channel_name_buf, 100, channel->pattern[locale], current_zone_name.c_str());
 #ifndef MANGOSBOT_ZERO
                 new_channel = cMgr->GetJoinChannel(new_channel_name_buf, channel->ChannelID);
 #else

--- a/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
+++ b/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
@@ -15,8 +15,14 @@ using namespace ai;
 map<string, int> SuggestWhatToDoAction::instances;
 map<string, int> SuggestWhatToDoAction::factions;
 
-SuggestWhatToDoAction::SuggestWhatToDoAction(PlayerbotAI* ai, string name) : InventoryAction(ai, name)
+SuggestWhatToDoAction::SuggestWhatToDoAction(PlayerbotAI* ai, string name)
+    : InventoryAction{ ai, name }
+    , _locale{ sConfig.GetIntDefault("DBC.Locale", 0 /*LocaleConstant::LOCALE_enUS*/) }
 {
+    // -- In case we're using auto detect on config file^M
+    if (_locale == 255)
+        _locale = static_cast<int32>(LocaleConstant::LOCALE_enUS);
+
     suggestions.push_back(&SuggestWhatToDoAction::instance);
     suggestions.push_back(&SuggestWhatToDoAction::specificQuest);
     suggestions.push_back(&SuggestWhatToDoAction::grindMaterials);
@@ -267,8 +273,8 @@ void SuggestWhatToDoAction::something()
         return;
 
     ostringstream out;
-    //out << "|cffb04040" << entry->area_name[0] << "|r";
-    out << entry->area_name[0];
+    //out << "|cffb04040" << entry->area_name[_locale] << "|r";
+    out << entry->area_name[_locale];
     placeholders["%zone"] = out.str();
 
     spam(BOT_TEXT2("suggest_something", placeholders), urand(0, 1) ? 0x18 : 0, !urand(0, 2), !urand(0, 3));
@@ -302,12 +308,12 @@ void SuggestWhatToDoAction::spam(string msg, uint8 flags, bool worldChat, bool g
         if (channel->ChannelID == 24)
 #endif
         {
-            string chanName = channel->pattern[0];
+            string chanName = channel->pattern[_locale];
             chn = cMgr->GetChannel(chanName, bot);
         }
         else
         {
-            snprintf(channelName, 100, channel->pattern[0], current_zone->area_name[0]);
+            snprintf(channelName, 100, channel->pattern[_locale], current_zone->area_name[_locale]);
             chn = cMgr->GetChannel(channelName, bot);
         }
 

--- a/playerbot/strategy/actions/SuggestWhatToDoAction.h
+++ b/playerbot/strategy/actions/SuggestWhatToDoAction.h
@@ -27,6 +27,7 @@ namespace ai
     private:
         static map<string, int> instances;
         static map<string, int> factions;
+        int32 _locale;
     };
 
     class SuggestTradeAction : public SuggestWhatToDoAction


### PR DESCRIPTION
Noticed bots werent talking except in World channel.
After investigation they're always talking in channel [0] wich is enUS locale.

My PR takes the value in the config file DBC.Locale and use it.
Now they're all talking in every channel.

If DBC.Locale is set to 255 im taking the default value of enUS 0.


Origin PR: https://github.com/celguar/mangos-tbc/pull/4