### PR TITLE
Fix healers moving back and forth

### DIFF
--- a/playerbot/AiFactory.cpp
+++ b/playerbot/AiFactory.cpp
@@ -205,7 +205,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             else
                 engine->addStrategies("heal", "threat", NULL);
 
-            engine->addStrategies("dps assist", "flee", "cure", "ranged", "cc", NULL);
+            engine->addStrategies("dps assist", "flee", "cure", "cc", NULL);
             break;
         case CLASS_MAGE:
             if (tab == 0)
@@ -215,7 +215,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             else
                 engine->addStrategies("frost", "frost aoe", "threat", NULL);
 
-            engine->addStrategies("dps", "dps assist", "flee", "cure", "ranged", "cc", NULL);
+            engine->addStrategies("dps", "dps assist", "flee", "cure", "cc", NULL);
             break;
         case CLASS_WARRIOR:
             if (tab == 2)
@@ -229,7 +229,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             if (tab == 0)
                 engine->addStrategies("caster", "caster aoe", "bmana", "threat", "flee", "ranged", NULL);
             else if (tab == 2)
-                engine->addStrategies("heal", "bmana", "flee", "ranged", NULL);
+                engine->addStrategies("heal", "bmana", "flee", NULL);
             else
                 engine->addStrategies("dps", "melee aoe", "bdps", "threat", "close", NULL);
 
@@ -239,7 +239,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             if (tab == 1)
                 engine->addStrategies("tank", "tank assist", "bthreat", "cure", "close", "cc", NULL);
 			else if(tab == 0)
-                engine->addStrategies("heal", "dps assist", "cure", "flee", "cc", "ranged", NULL);
+                engine->addStrategies("heal", "dps assist", "cure", "flee", "cc", NULL);
             else
                 engine->addStrategies("dps", "dps assist", "cure", "close", "cc", NULL);
 
@@ -255,12 +255,12 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
         case CLASS_DRUID:
             if (tab == 0)
             {
-                engine->addStrategies("caster", "cure", "caster aoe", "threat", "flee", "dps assist", "ranged", "cc", NULL);
+                engine->addStrategies("caster", "cure", "caster aoe", "threat", "flee", "dps assist", "cc", NULL);
                 if (player->GetLevel() > 19)
                     engine->addStrategy("caster debuff");
             }
             else if (tab == 2)
-                engine->addStrategies("heal", "cure", "flee", "dps assist", "ranged", "cc", NULL);
+                engine->addStrategies("heal", "cure", "flee", "dps assist", "cc", NULL);
             else
             {
                 engine->removeStrategy("ranged");
@@ -287,7 +287,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             if (player->GetLevel() > 19)
                 engine->addStrategy("dps debuff");
 
-            engine->addStrategies("dps assist", "dps", "flee", "ranged", "cc", "pet", "threat", "aoe", NULL);
+            engine->addStrategies("dps assist", "dps", "flee", "cc", "pet", "threat", "aoe", NULL);
             break;
 #ifdef MANGOSBOT_TWO
         case CLASS_DEATH_KNIGHT:

--- a/playerbot/strategy/generic/RangedCombatStrategy.cpp
+++ b/playerbot/strategy/generic/RangedCombatStrategy.cpp
@@ -9,10 +9,6 @@ void RangedCombatStrategy::InitTriggers(list<TriggerNode*> &triggers)
 {
     CombatStrategy::InitTriggers(triggers);
 
-    /*triggers.push_back(new TriggerNode(
-        "enemy too close for shoot",
-        NextAction::array(0, new NextAction("flee", ACTION_HIGH), NULL)));*/
-
     triggers.push_back(new TriggerNode(
         "enemy too close for spell",
         NextAction::array(0, new NextAction("flee", 59.0f), NULL)));

--- a/playerbot/strategy/paladin/HealPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/HealPaladinStrategy.cpp
@@ -22,11 +22,6 @@ HealPaladinStrategy::HealPaladinStrategy(PlayerbotAI* ai) : GenericPaladinStrate
     actionNodeFactories.Add(new HealPaladinStrategyActionNodeFactory());
 }
 
-NextAction** HealPaladinStrategy::getDefaultActions()
-{
-    return NextAction::array(0, new NextAction("reach party member to heal", ACTION_NORMAL + 1), new NextAction("judgement", ACTION_NORMAL), NULL);
-}
-
 void HealPaladinStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericPaladinStrategy::InitTriggers(triggers);

--- a/playerbot/strategy/paladin/HealPaladinStrategy.h
+++ b/playerbot/strategy/paladin/HealPaladinStrategy.h
@@ -12,7 +12,6 @@ namespace ai
     public:
         virtual void InitTriggers(std::list<TriggerNode*> &triggers);
         virtual string getName() { return "heal"; }
-        virtual NextAction** getDefaultActions();
 		virtual int GetType() { return STRATEGY_TYPE_HEAL | STRATEGY_TYPE_MELEE; }
     };
 }

--- a/playerbot/strategy/priest/HealPriestStrategy.cpp
+++ b/playerbot/strategy/priest/HealPriestStrategy.cpp
@@ -11,11 +11,6 @@ HealPriestStrategy::HealPriestStrategy(PlayerbotAI* ai) : GenericPriestStrategy(
     actionNodeFactories.Add(new GenericPriestStrategyActionNodeFactory());
 }
 
-NextAction** HealPriestStrategy::getDefaultActions()
-{
-    return NextAction::array(0, new NextAction("reach party member to heal", 1.0f), NULL);
-}
-
 void HealPriestStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericPriestStrategy::InitTriggers(triggers);

--- a/playerbot/strategy/priest/HealPriestStrategy.h
+++ b/playerbot/strategy/priest/HealPriestStrategy.h
@@ -11,7 +11,6 @@ namespace ai
 
     public:
         virtual void InitTriggers(std::list<TriggerNode*> &triggers);
-        virtual NextAction** getDefaultActions();
         virtual string getName() { return "heal"; }
 		virtual int GetType() { return STRATEGY_TYPE_HEAL; }
     };


### PR DESCRIPTION
Fix paladin and priest healers always moving back and forth around the target, ignoring other movement actions