### PR TITLE
Fix Linux compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,8 +202,8 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src/game/Weather
     ${CMAKE_SOURCE_DIR}/src/game/World
     ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers
-    ${CMAKE_SOURCE_DIR}/src/game/movement
-    ${CMAKE_SOURCE_DIR}/src/game/vmap
+    ${CMAKE_SOURCE_DIR}/src/game/Movement
+    ${CMAKE_SOURCE_DIR}/src/game/Vmap
     ${CMAKE_SOURCE_DIR}/src/shared
     ${CMAKE_SOURCE_DIR}/src/shared/Auth
     ${CMAKE_SOURCE_DIR}/src/shared/Config

--- a/ahbot/TradeCategory.cpp
+++ b/ahbot/TradeCategory.cpp
@@ -4,6 +4,8 @@
 #include "PricingStrategy.h"
 #include "ServerFacade.h"
 #include "SQLStorages.h"
+#include "DBCStructure.h"
+#include "ItemPrototype.h"
 #ifdef CMANGOS
 #include "Globals/ObjectMgr.h"
 #include "SpellEffectDefines.h"

--- a/ahbot/TradeCategory.h
+++ b/ahbot/TradeCategory.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "Category.h"
 
+struct ItemPrototype;
+struct SpellEntry;
+
 using namespace std;
 
 namespace ahbot

--- a/playerbot/AiFactory.cpp
+++ b/playerbot/AiFactory.cpp
@@ -1,6 +1,7 @@
 #include "../botpch.h"
 #include "playerbot.h"
 #include "AiFactory.h"
+#include "strategy/AiObjectContext.h"
 #include "strategy/Engine.h"
 
 #include "strategy/priest/PriestAiObjectContext.h"

--- a/playerbot/AiFactory.h
+++ b/playerbot/AiFactory.h
@@ -1,6 +1,14 @@
 #pragma once
 
+#include "PlayerbotAI.h"
+
 class Player;
+
+namespace ai
+{
+    class AiObjectContext;
+    class Engine;
+}
 
 using namespace ai;
 

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -308,7 +308,7 @@ public:
     bool PlaySound(uint32 emote);
     bool PlayEmote(uint32 emote);
     void Ping(float x, float y);
-    void PlayerbotAI::Poi(float x, float y, string icon_name = "This way", Player* player = nullptr, uint32 flags = 99, uint32 icon = 7 /* red flag */, uint32 icon_data = 0);
+    void Poi(float x, float y, string icon_name = "This way", Player* player = nullptr, uint32 flags = 99, uint32 icon = 7 /* red flag */, uint32 icon_data = 0);
     Item * FindPoison() const;
     Item * FindConsumable(uint32 displayId) const;
     Item * FindBandage() const;

--- a/playerbot/PlayerbotAIAware.h
+++ b/playerbot/PlayerbotAIAware.h
@@ -1,5 +1,7 @@
 #pragma once
 
+class PlayerbotAI;
+
 namespace ai
 {
     class PlayerbotAIAware 

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -2,6 +2,7 @@
 
 #include "Config.h"
 #include "Talentspec.h"
+#include "SharedDefines.h"
 
 class Player;
 class PlayerbotMgr;

--- a/playerbot/Talentspec.cpp
+++ b/playerbot/Talentspec.cpp
@@ -1,6 +1,7 @@
 #include "playerbot.h"
 #include "Talentspec.h"
 #include "ServerFacade.h"
+#include "DBCStructure.h"
 
 using namespace std::placeholders;
 

--- a/playerbot/Talentspec.h
+++ b/playerbot/Talentspec.h
@@ -1,5 +1,10 @@
 #pragma once
+
+#include "Player.h"
 //#include "playerbot.h"
+
+struct TalentEntry;
+struct TalentTabEntry;
 
 class TalentSpec {
     public:

--- a/playerbot/TravelMgr.cpp
+++ b/playerbot/TravelMgr.cpp
@@ -6,7 +6,16 @@
 #include "TravelNode.h"
 #include "PlayerbotAI.h"
 
+#include "ByteBuffer.h"
+#include "Creature.h"
+#include "GameObject.h"
+#include "Map.h"
+#include "Object.h"
 #include "ObjectMgr.h"
+#include "ObjectGuid.h"
+#include "Player.h"
+#include "Unit.h"
+#include "QuestDef.h"
 #include <numeric>
 #include <iomanip>
 
@@ -276,7 +285,8 @@ void WorldPosition::printWKT(vector<WorldPosition> points, ostringstream& out, u
 
 WorldPosition WorldPosition::getDisplayLocation() 
 { 
-    return offset(&sTravelNodeMap.getMapOffset(getMapId())); 
+    auto mapOffset = sTravelNodeMap.getMapOffset(getMapId());
+    return offset(&mapOffset);
 };
 
 AreaTableEntry const* WorldPosition::getArea()
@@ -1074,7 +1084,8 @@ bool QuestRelationTravelDestination::isActive(Player* bot) {
         //Do not try to hand-in dungeon/elite quests in instances without a group.
         if ((questTemplate->GetType() == QUEST_TYPE_ELITE || questTemplate->GetType() == QUEST_TYPE_DUNGEON) && !AI_VALUE(bool, "can fight boss"))
         {
-            if (!this->nearestPoint(&WorldPosition(bot))->isOverworld())
+            auto pos = WorldPosition(bot);
+            if (!this->nearestPoint(&pos)->isOverworld())
                 return false;
         }
     }
@@ -1125,7 +1136,8 @@ bool QuestObjectiveTravelDestination::isActive(Player* bot) {
         //Do not try to hand-in dungeon/elite quests in instances without a group.
         if (cInfo->Rank > CREATURE_ELITE_NORMAL)
         {
-            if (!this->nearestPoint(&WorldPosition(bot))->isOverworld() && !AI_VALUE(bool, "can fight boss"))
+            auto pos = WorldPosition(bot);
+            if (!this->nearestPoint(&pos)->isOverworld() && !AI_VALUE(bool, "can fight boss"))
                 return false;
             else if (!AI_VALUE(bool, "can fight elite"))
                 return false;
@@ -1138,14 +1150,16 @@ bool QuestObjectiveTravelDestination::isActive(Player* bot) {
     //Do not try to do dungeon/elite quests in instances without a group.
     if ((questTemplate->GetType() == QUEST_TYPE_ELITE || questTemplate->GetType() == QUEST_TYPE_DUNGEON || questTemplate->GetType() == QUEST_TYPE_RAID) && !AI_VALUE(bool, "can fight boss"))
     {
-        if (!this->nearestPoint(&WorldPosition(bot))->isOverworld())
+        auto pos = WorldPosition(bot);
+        if (!this->nearestPoint(&pos)->isOverworld())
             return false;
     }
 
     //Do not try to do pvp quests in bg's (no way to travel there). 
     if (questTemplate->GetType() == QUEST_TYPE_PVP)
     {
-        if (!this->nearestPoint(&WorldPosition(bot))->isOverworld())
+        auto pos = WorldPosition(bot);
+        if (!this->nearestPoint(&pos)->isOverworld())
             return false;
     }
 

--- a/playerbot/TravelMgr.h
+++ b/playerbot/TravelMgr.h
@@ -1,8 +1,15 @@
 #pragma once
 
+#include "strategy/AiObject.h"
 #include "MoveSplineInitArgs.h"
 #include <boost/functional/hash.hpp>
+#include "ObjectMgr.h"
+#include "SpellMgr.h"
+#include "PlayerbotAIConfig.h"
 #include "GridDefines.h"
+#include "SharedDefines.h"
+
+class ByteBuffer;
 
 namespace G3D
 {

--- a/playerbot/TravelNode.cpp
+++ b/playerbot/TravelNode.cpp
@@ -6,6 +6,8 @@
 #include <iomanip>
 #include <regex>
 
+#include "ObjectMgr.h"
+#include "PlayerbotAI.h"
 #include "MoveMapSharedDefines.h"
 #include "MotionGenerators/PathFinder.h"
 #include "Entities/Transports.h"

--- a/playerbot/TravelNode.h
+++ b/playerbot/TravelNode.h
@@ -54,6 +54,8 @@ enum class TravelNodePathType : uint8
     staticPortal = 6
 };
 
+using namespace ai;
+
     //A connection between two nodes. 
     class TravelNodePath
     {
@@ -293,7 +295,7 @@ enum class TravelNodePathType : uint8
         vector<WorldPosition> getPointPath() { vector<WorldPosition> retVec; for (const auto& p : fullPath) retVec.push_back(p.point); return retVec; };
 
         bool makeShortCut(WorldPosition startPos, float maxDist);
-        bool TravelPath::shouldMoveToNextPoint(WorldPosition startPos, vector<PathNodePoint>::iterator beg, vector<PathNodePoint>::iterator ed, vector<PathNodePoint>::iterator p, float &moveDist, float maxDist);
+        bool shouldMoveToNextPoint(WorldPosition startPos, vector<PathNodePoint>::iterator beg, vector<PathNodePoint>::iterator ed, vector<PathNodePoint>::iterator p, float &moveDist, float maxDist);
         WorldPosition getNextPoint(WorldPosition startPos, float maxDist, TravelNodePathType& pathType, uint32& entry);
 
         ostringstream print();

--- a/playerbot/strategy/Action.cpp
+++ b/playerbot/strategy/Action.cpp
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include "AiObjectContext.h"
 #include "Action.h"
+#include "Unit.h"
 
 using namespace ai;
 

--- a/playerbot/strategy/Action.h
+++ b/playerbot/strategy/Action.h
@@ -3,6 +3,14 @@
 #include "Value.h"
 #include "AiObject.h"
 
+class Unit;
+
+namespace ai
+{
+    class NextAction;
+    template<class T> class Value;
+}
+
 namespace ai
 {
     class NextAction

--- a/playerbot/strategy/AiObject.cpp
+++ b/playerbot/strategy/AiObject.cpp
@@ -1,6 +1,7 @@
 #include "../../botpch.h"
 #include "../playerbot.h"
 #include "AiObject.h"
+#include "Player.h"
 
 AiObject::AiObject(PlayerbotAI* ai) :
     PlayerbotAIAware(ai),

--- a/playerbot/strategy/AiObject.h
+++ b/playerbot/strategy/AiObject.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "PlayerbotAIAware.h"
+
+class Player;
 class PlayerbotAI;
+
+using namespace std;
 
 namespace ai
 {

--- a/playerbot/strategy/AiObjectContext.cpp
+++ b/playerbot/strategy/AiObjectContext.cpp
@@ -1,5 +1,6 @@
 #include "../../botpch.h"
 #include "../playerbot.h"
+#include "Action.h"
 #include "AiObjectContext.h"
 #include "NamedObjectContext.h"
 #include "StrategyContext.h"
@@ -33,6 +34,29 @@ AiObjectContext::AiObjectContext(PlayerbotAI* ai) : PlayerbotAIAware(ai)
     valueContexts.Add(new ValueContext());
 
     valueContexts.Add(&sSharedValueContext);
+}
+
+string AiObjectContext::FormatValues(string findName)
+{
+    ostringstream out;
+    set<string> names = valueContexts.GetCreated();
+    for (set<string>::iterator i = names.begin(); i != names.end(); ++i)
+    {
+        UntypedValue* value = GetUntypedValue(*i);
+        if (!value)
+            continue;
+
+        if (!findName.empty() && i->find(findName) == string::npos)
+            continue;
+
+        string text = value->Format();
+        if (text == "?")
+            continue;
+
+        out << "{" << *i << "=" << text << "}|";
+    }
+    out.seekp(-1, out.cur);
+    return out.str();
 }
 
 void AiObjectContext::Update()

--- a/playerbot/strategy/AiObjectContext.h
+++ b/playerbot/strategy/AiObjectContext.h
@@ -8,6 +8,12 @@
 
 namespace ai
 {
+    class UntypedValue;
+    template<class T> class Value;
+}
+
+namespace ai
+{
     class AiObjectContext : public PlayerbotAIAware
     {
     public:
@@ -55,28 +61,7 @@ namespace ai
             return actionContexts.supports();
         }
 
-        string FormatValues(string findName = "")
-        {
-            ostringstream out;
-            set<string> names = valueContexts.GetCreated();
-            for (set<string>::iterator i = names.begin(); i != names.end(); ++i)
-            {
-                UntypedValue* value = GetUntypedValue(*i);
-                if (!value)
-                    continue;
-
-                if (!findName.empty() && i->find(findName) == string::npos)
-                    continue;
-
-                string text = value->Format();
-                if (text == "?")
-                    continue;
-
-                out << "{" << *i << "=" << text << "}|";
-            }
-            out.seekp(-1, out.cur);
-            return out.str();
-        }
+        string FormatValues(string findName = "");
 
     public:
         virtual void Update();

--- a/playerbot/strategy/Event.cpp
+++ b/playerbot/strategy/Event.cpp
@@ -1,5 +1,6 @@
 #include "../../botpch.h"
 #include "../playerbot.h"
+#include "Player.h"
 #include "Event.h"
 
 

--- a/playerbot/strategy/Event.h
+++ b/playerbot/strategy/Event.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include "ObjectGuid.h"
+#include "WorldPacket.h"
+
+class Player;
+
+using namespace std;
+
 namespace ai
 {
     class Event

--- a/playerbot/strategy/Multiplier.cpp
+++ b/playerbot/strategy/Multiplier.cpp
@@ -1,5 +1,6 @@
 #include "../../botpch.h"
 #include "../playerbot.h"
 #include "Multiplier.h"
+#include "Action.h"
 
 using namespace ai;

--- a/playerbot/strategy/Multiplier.h
+++ b/playerbot/strategy/Multiplier.h
@@ -1,5 +1,13 @@
 #pragma once
-#include "Action.h"
+
+#include "AiObject.h"
+
+class PlayerbotAI;
+
+namespace ai
+{
+    class Action;
+}
 
 namespace ai
 {

--- a/playerbot/strategy/Strategy.cpp
+++ b/playerbot/strategy/Strategy.cpp
@@ -2,6 +2,7 @@
 #include "../playerbot.h"
 #include "Strategy.h"
 #include "NamedObjectContext.h"
+#include "Action.h"
 
 using namespace ai;
 using namespace std;

--- a/playerbot/strategy/Strategy.h
+++ b/playerbot/strategy/Strategy.h
@@ -6,6 +6,9 @@
 
 namespace ai
 {
+	class ActionNode;
+	class NextAction;
+
 	enum StrategyType
 	{
 		STRATEGY_TYPE_GENERIC = 0,

--- a/playerbot/strategy/Trigger.cpp
+++ b/playerbot/strategy/Trigger.cpp
@@ -2,6 +2,8 @@
 #include "../playerbot.h"
 #include "Trigger.h"
 #include "Action.h"
+#include "Unit.h"
+#include "Value.h"
 
 using namespace ai;
 
@@ -24,4 +26,19 @@ Value<Unit*>* Trigger::GetTargetValue()
 Unit* Trigger::GetTarget()
 {
     return GetTargetValue()->Get();
+}
+
+TriggerNode::~TriggerNode()
+{
+	NextAction::destroy(handlers);
+}
+
+NextAction** TriggerNode::getHandlers()
+{
+	return NextAction::merge(NextAction::clone(handlers), trigger->getHandlers());
+}
+
+float TriggerNode::getFirstRelevance()
+{
+	return handlers[0] ? handlers[0]->getRelevance() : -1;
 }

--- a/playerbot/strategy/Trigger.h
+++ b/playerbot/strategy/Trigger.h
@@ -1,7 +1,15 @@
 #pragma once
-#include "Action.h"
 #include "Event.h"
-#include "../PlayerbotAIAware.h"
+#include "Value.h"
+#include "AiObject.h"
+
+class Unit;
+
+namespace ai
+{
+    class NextAction;
+    template<class T> class Value;
+}
 
 namespace ai
 {
@@ -52,10 +60,7 @@ namespace ai
             this->handlers = handlers;
             this->trigger = NULL;
         }
-        virtual ~TriggerNode()
-        {
-            NextAction::destroy(handlers);
-        }
+        virtual ~TriggerNode();
 
     public:
         Trigger* getTrigger() { return trigger; }
@@ -63,8 +68,8 @@ namespace ai
         string getName() { return name; }
 
     public:
-        NextAction** getHandlers() { return NextAction::merge(NextAction::clone(handlers), trigger->getHandlers()); }
-        float getFirstRelevance() {return handlers[0] ? handlers[0]->getRelevance() : -1; }
+        NextAction** getHandlers();
+        float getFirstRelevance();
     private:
         std::string name;
         Trigger* trigger;

--- a/playerbot/strategy/actions/ActionContext.h
+++ b/playerbot/strategy/actions/ActionContext.h
@@ -33,7 +33,7 @@
 #include "RpgAction.h"
 #include "TravelAction.h"
 #include "RtiAction.h"
-#include "BattlegroundTactics.h"
+#include "BattleGroundTactics.h"
 #include "CheckMountStateAction.h"
 #include "ChangeTalentsAction.h"
 #include "AutoLearnSpellAction.h"

--- a/playerbot/strategy/actions/AhAction.cpp
+++ b/playerbot/strategy/actions/AhAction.cpp
@@ -162,8 +162,9 @@ bool AhBidAction::Execute(string text, Unit* auctioneer)
 
     if (text == "vendor")
     {
+        auto data = WorldPacket();
         uint32 count, totalcount = 0;
-        auctionHouse->BuildListBidderItems(WorldPacket(), bot, 9999, count, totalcount);
+        auctionHouse->BuildListBidderItems(data, bot, 9999, count, totalcount);
 
         if (totalcount > 10) //Already have 10 bids, stop.
             return false;

--- a/playerbot/strategy/actions/BattleGroundJoinAction.cpp
+++ b/playerbot/strategy/actions/BattleGroundJoinAction.cpp
@@ -1,7 +1,7 @@
 #include "ObjectGuid.h"
 #include "botpch.h"
 #include "../../playerbot.h"
-#include "../../playerbotAI.h"
+#include "../../PlayerbotAI.h"
 #include "LfgActions.h"
 #include "../../AiFactory.h"
 //#include "../../PlayerbotAIConfig.h"
@@ -26,7 +26,7 @@
 #include "MotionGenerators/TargetedMovementGenerator.h"
 #include "BattleGround.h"
 #include "BattleGroundMgr.h"
-#include "BattlegroundJoinAction.h"
+#include "BattleGroundJoinAction.h"
 #ifndef MANGOSBOT_ZERO
 #ifdef CMANGOS
 #include "Arena/ArenaTeam.h"

--- a/playerbot/strategy/actions/BattleGroundTactics.cpp
+++ b/playerbot/strategy/actions/BattleGroundTactics.cpp
@@ -4,7 +4,7 @@
 #include "MovementActions.h"
 #include "BattleGround.h"
 #include "BattleGroundMgr.h"
-#include "BattlegroundTactics.h"
+#include "BattleGroundTactics.h"
 #ifdef MANGOSBOT_TWO
 #include "Entities/Vehicle.h"
 #endif

--- a/playerbot/strategy/actions/ChangeTalentsAction.cpp
+++ b/playerbot/strategy/actions/ChangeTalentsAction.cpp
@@ -1,6 +1,6 @@
 #include "botpch.h"
 #include "../../playerbot.h"
-#include "../../talentspec.h"
+#include "../../Talentspec.h"
 #include "ChangeTalentsAction.h"
 
 using namespace ai;

--- a/playerbot/strategy/actions/ChangeTalentsAction.h
+++ b/playerbot/strategy/actions/ChangeTalentsAction.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "botpch.h"
 #include "../../playerbot.h"
-#include "../../talentspec.h"
+#include "../../Talentspec.h"
 #include "../Action.h"
 
 namespace ai
@@ -16,7 +16,7 @@ namespace ai
     private:
         std::vector<TalentPath*> getPremadePaths(string findName);
         std::vector<TalentPath*> getPremadePaths(TalentSpec* oldSpec);
-        TalentPath* ChangeTalentsAction::getPremadePath(int id);
+        TalentPath* getPremadePath(int id);
         void listPremadePaths(std::vector<TalentPath*> paths, ostringstream* out);
         TalentPath* PickPremadePath(std::vector<TalentPath*> paths, bool useProbability);
         TalentSpec* GetBestPremadeSpec(int spec);

--- a/playerbot/strategy/actions/ChatActionContext.h
+++ b/playerbot/strategy/actions/ChatActionContext.h
@@ -67,7 +67,7 @@
 #include "PassLeadershipToMasterAction.h"
 #include "CheatAction.h"
 #include "GuildManagementActions.h"
-#include "RTSCAction.h"
+#include "RtscAction.h"
 
 namespace ai
 {

--- a/playerbot/strategy/actions/ChooseRpgTargetAction.cpp
+++ b/playerbot/strategy/actions/ChooseRpgTargetAction.cpp
@@ -3,7 +3,7 @@
 #include "ChooseRpgTargetAction.h"
 #include "../../PlayerbotAIConfig.h"
 #include "../values/PossibleRpgTargetsValue.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 #include "../values/BudgetValues.h"
 #include "GuildCreateActions.h"
 #include "../values/Formations.h"

--- a/playerbot/strategy/actions/ChooseTravelTargetAction.cpp
+++ b/playerbot/strategy/actions/ChooseTravelTargetAction.cpp
@@ -64,7 +64,8 @@ void ChooseTravelTargetAction::getNewTarget(TravelTarget* newTarget, TravelTarge
     bool pvpActivate = false;
     if (pvpActivate && !foundTarget && urand(0, 4) && bot->GetLevel() > 50)
     {
-        WorldPosition* botPos = &WorldPosition(bot);
+        WorldPosition pos = WorldPosition(bot);
+        WorldPosition* botPos = &pos;
         TravelTarget* target = context->GetValue<TravelTarget*>("travel target")->Get();
 
         TravelDestination* dest = ChooseTravelTargetAction::FindDestination(bot, "Tarren Mill");
@@ -734,7 +735,8 @@ char* strstri(const char* haystack, const char* needle);
 
 bool ChooseTravelTargetAction::SetNpcFlagTarget(TravelTarget* target, vector<NPCFlags> flags, string name, vector<uint32> items)
 {
-    WorldPosition* botPos = &WorldPosition(bot);
+    WorldPosition pos = WorldPosition(bot);
+    WorldPosition* botPos = &pos;
 
     vector<TravelDestination*> TravelDestinations;
 
@@ -869,7 +871,8 @@ TravelDestination* ChooseTravelTargetAction::FindDestination(Player* bot, string
             dests.push_back(d);
     }
 
-    WorldPosition* botPos = &WorldPosition(bot);
+    WorldPosition pos = WorldPosition(bot);
+    WorldPosition* botPos = &pos;
 
     if (dests.empty())
         return nullptr;

--- a/playerbot/strategy/actions/ChooseTravelTargetAction.h
+++ b/playerbot/strategy/actions/ChooseTravelTargetAction.h
@@ -2,7 +2,7 @@
 
 #include "../Action.h"
 #include "MovementActions.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 
 namespace ai
 {

--- a/playerbot/strategy/actions/DebugAction.cpp
+++ b/playerbot/strategy/actions/DebugAction.cpp
@@ -461,8 +461,9 @@ bool DebugAction::Execute(Event event)
     }
     else if (text.find("loot ") != std::string::npos)
     {
-        ostringstream out;
-        for (auto itemId : chat->parseItems(text.substr(5)))
+        std::string textSubstr;
+        std::ostringstream out;
+        for (auto itemId : chat->parseItems(textSubstr = text.substr(5)))
         {
             list<int32> entries = GAI_VALUE2(list<int32>, "item drop list", itemId);
 
@@ -479,7 +480,8 @@ bool DebugAction::Execute(Event event)
 
             for (auto entry : entries)
             {
-                string qualifier = Qualified::MultiQualify({ to_string(entry) , to_string(itemId) });
+                std::vector<std::string> qualifiers = { to_string(entry), to_string(itemId) };
+                std::string qualifier = Qualified::MultiQualify(qualifiers);
                 float chance = GAI_VALUE2(float, "loot chance", qualifier);
                 if(chance > 0)
                     chances.push_back(make_pair(entry, chance));
@@ -543,8 +545,9 @@ bool DebugAction::Execute(Event event)
     }
     else if (text.find("drops ") != std::string::npos)
     {
-    ostringstream out;
-    for (auto entry : chat->parseWorldEntries(text.substr(6)))
+    std::string textSubstr;
+    std::ostringstream out;
+    for (auto entry : chat->parseWorldEntries(textSubstr = text.substr(6)))
     {
         list<uint32> itemIds = GAI_VALUE2(list<uint32>, "entry loot list", entry);
 
@@ -561,7 +564,8 @@ bool DebugAction::Execute(Event event)
 
         for (auto itemId : itemIds)
         {
-            string qualifier = Qualified::MultiQualify({ to_string(entry) , to_string(itemId) });
+            std::vector<std::string> qualifiers = { to_string(entry) , to_string(itemId) };
+            std::string qualifier = Qualified::MultiQualify(qualifiers);
             float chance = GAI_VALUE2(float, "loot chance", qualifier);
             if (chance > 0 && sObjectMgr.GetItemPrototype(itemId))
             {

--- a/playerbot/strategy/actions/GoAction.cpp
+++ b/playerbot/strategy/actions/GoAction.cpp
@@ -5,7 +5,7 @@
 #include "../../ServerFacade.h"
 #include "../values/Formations.h"
 #include "../values/PositionValue.h"
-#include "travelMgr.h"
+#include "TravelMgr.h"
 #include "MotionGenerators/PathFinder.h"
 #include "ChooseTravelTargetAction.h"
 
@@ -34,7 +34,8 @@ bool GoAction::Execute(Event event)
     
     if (param.find("travel") != string::npos && param.size()> 7)
     {
-        WorldPosition* botPos = &WorldPosition(bot);
+        WorldPosition pos = WorldPosition(bot);
+        WorldPosition* botPos = &pos;
 
         string destination = param.substr(7);
 

--- a/playerbot/strategy/actions/LfgActions.cpp
+++ b/playerbot/strategy/actions/LfgActions.cpp
@@ -969,7 +969,8 @@ bool LfgJoinAction::JoinLFG()
 
     // Set Raid Browser comment
     string _gs = to_string(bot->GetEquipGearScore());
-    sLFGMgr.JoinLfg(bot, GetRoles(), list, "Bot " + _roles + " GS:" + _gs + " for LFG");
+    string comment = "Bot " + _roles + " GS:" + _gs + " for LFG";
+    sLFGMgr.JoinLfg(bot, GetRoles(), list, comment);
 #endif
     return true;
 }

--- a/playerbot/strategy/actions/LfgActions.h
+++ b/playerbot/strategy/actions/LfgActions.h
@@ -14,9 +14,9 @@
 #include "LFG/LFGMgr.h"
 #include "LFG/LFG.h"
 #endif
-#include "Battleground.h"
-#include "BattlegroundMgr.h"
-#include "BattlegroundWS.h"
+#include "BattleGround.h"
+#include "BattleGroundMgr.h"
+#include "BattleGroundWS.h"
 #include "ChooseTargetActions.h"
 #include "CheckMountStateAction.h"
 #include "G3D/Vector3.h"

--- a/playerbot/strategy/actions/ListQuestsActions.cpp
+++ b/playerbot/strategy/actions/ListQuestsActions.cpp
@@ -1,7 +1,7 @@
 #include "botpch.h"
 #include "../../playerbot.h"
 #include "ListQuestsActions.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 
 
 using namespace ai;
@@ -57,7 +57,8 @@ void ListQuestsAction::ListQuests(QuestListFilter filter, QuestTravelDetail trav
 int ListQuestsAction::ListQuests(bool completed, bool silent, QuestTravelDetail travelDetail)
 {
     TravelTarget* target;
-    WorldPosition* botPos = &WorldPosition(bot);
+    WorldPosition pos = WorldPosition(bot);
+    WorldPosition* botPos = &pos;
     
     if (travelDetail != QUEST_TRAVEL_DETAIL_NONE)
         target = context->GetValue<TravelTarget*>("travel target")->Get();

--- a/playerbot/strategy/actions/MoveToRpgTargetAction.cpp
+++ b/playerbot/strategy/actions/MoveToRpgTargetAction.cpp
@@ -5,7 +5,7 @@
 #include "../../PlayerbotAIConfig.h"
 #include "../../ServerFacade.h"
 #include "../values/PossibleRpgTargetsValue.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 #include "ChooseRpgTargetAction.h"
 
 using namespace ai;

--- a/playerbot/strategy/actions/MoveToTravelTargetAction.h
+++ b/playerbot/strategy/actions/MoveToTravelTargetAction.h
@@ -3,7 +3,7 @@
 #include "../Action.h"
 #include "MovementActions.h"
 #include "../values/LastMovementValue.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 
 namespace ai
 {

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -162,8 +162,8 @@ bool MovementAction::FlyDirect(WorldPosition &startPosition, WorldPosition &endP
         if (path.empty())
             return false;
 
-
-        for (auto& p = path.end(); p-- != path.begin(); ) //Find the furtest point where we can fly to directly.
+        auto pathEnd = path.end();
+        for (auto& p = pathEnd; p-- != path.begin(); ) //Find the furtest point where we can fly to directly.
             if (p->getMapId() == startPosition.getMapId() && p->isOutside())
             {
                 movePosition = *p;

--- a/playerbot/strategy/actions/QueryQuestAction.cpp
+++ b/playerbot/strategy/actions/QueryQuestAction.cpp
@@ -1,7 +1,7 @@
 #include "botpch.h"
 #include "../../playerbot.h"
 #include "QueryQuestAction.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 
 
 using namespace ai;
@@ -14,8 +14,9 @@ void QueryQuestAction::TellObjective(string name, int available, int required)
 bool QueryQuestAction::Execute(Event event)
 {
     Player *bot = ai->GetBot();
-    WorldPosition* botPos = &WorldPosition(bot);
-    string text = event.getParam();
+    WorldPosition pos = WorldPosition(bot);
+    WorldPosition* botPos = &pos;
+    std::string text = event.getParam();
     bool travel = false;
 
     if (text.find("travel") != std::string::npos)

--- a/playerbot/strategy/actions/UseTrinketAction.cpp
+++ b/playerbot/strategy/actions/UseTrinketAction.cpp
@@ -1,6 +1,9 @@
 #include "botpch.h"
 #include "../../playerbot.h"
 #include "UseTrinketAction.h"
+#include "Item.h"
+#include "ItemPrototype.h"
+#include "Player.h"
 
 using namespace ai;
 
@@ -11,7 +14,7 @@ bool UseTrinketAction::Execute(Event event)
 	if (trinkets.empty())
 		return false;
 
-	for each (Item * item in trinkets)
+	for (Item * item : trinkets)
 	{
 		ItemPrototype const* proto = item->GetProto();
 

--- a/playerbot/strategy/actions/WorldPacketActionContext.h
+++ b/playerbot/strategy/actions/WorldPacketActionContext.h
@@ -25,7 +25,7 @@
 #include "GuildAcceptAction.h"
 #include "AcceptBattleGroundInvitationAction.h"
 #include "PetitionSignAction.h"
-#include "BattlegroundJoinAction.h"
+#include "BattleGroundJoinAction.h"
 #include "SeeSpellAction.h"
 #include "ArenaTeamActions.h"
 

--- a/playerbot/strategy/generic/NonCombatStrategy.cpp
+++ b/playerbot/strategy/generic/NonCombatStrategy.cpp
@@ -1,7 +1,7 @@
 #include "botpch.h"
 #include "../../playerbot.h"
 #include "NonCombatStrategy.h"
-#include "../value.h"
+#include "../Value.h"
 
 using namespace ai;
 

--- a/playerbot/strategy/paladin/PaladinActions.cpp
+++ b/playerbot/strategy/paladin/PaladinActions.cpp
@@ -80,7 +80,7 @@ Unit* CastBlessingOnPartyAction::GetTarget()
     //nearestGroupPlayers.insert(nearestGroupPlayers.end(), nearestPlayers.begin(), nearestPlayers.end());
     nearestPlayers = nearestGroupPlayers;
     if (nearestPlayers.empty())
-        return false;
+        return NULL;
 
     Unit* trueTarget = nullptr;
     for (auto guid : nearestPlayers)

--- a/playerbot/strategy/triggers/TravelTriggers.cpp
+++ b/playerbot/strategy/triggers/TravelTriggers.cpp
@@ -3,7 +3,7 @@
 #include "TravelTriggers.h"
 
 #include "../../PlayerbotAIConfig.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 #include "ServerFacade.h"
 using namespace ai;
 

--- a/playerbot/strategy/values/BudgetValues.h
+++ b/playerbot/strategy/values/BudgetValues.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "../Value.h"
+#include "../NamedObjectContext.h"
+
 namespace ai
 {
     enum class NeedMoneyFor : uint32

--- a/playerbot/strategy/values/ItemCountValue.cpp
+++ b/playerbot/strategy/values/ItemCountValue.cpp
@@ -1,6 +1,9 @@
 #include "botpch.h"
 #include "../../playerbot.h"
 #include "ItemCountValue.h"
+#include "Item.h"
+#include "ItemPrototype.h"
+#include "Player.h"
 
 using namespace ai;
 
@@ -52,7 +55,7 @@ list<Item*> EquipedUsableTrinketValue::Calculate()
 	if (trinkets.empty())
 		return result;
 
-	for each (Item * item in trinkets)
+	for (Item * item : trinkets)
 	{
 		ItemPrototype const* proto = item->GetProto();
 

--- a/playerbot/strategy/values/ItemUsageValue.h
+++ b/playerbot/strategy/values/ItemUsageValue.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../Value.h"
+#include "../NamedObjectContext.h"
 
 namespace ai
 {

--- a/playerbot/strategy/values/PossibleRpgTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleRpgTargetsValue.cpp
@@ -7,7 +7,7 @@
 #include "GridNotifiersImpl.h"
 #include "CellImpl.h"
 #include "NearestUnitsValue.h"
-#include "../../Travelmgr.h"
+#include "../../TravelMgr.h"
 
 using namespace ai;
 using namespace MaNGOS;

--- a/playerbot/strategy/values/RTSCValues.h
+++ b/playerbot/strategy/values/RTSCValues.h
@@ -10,7 +10,7 @@ namespace ai
 
         virtual bool EqualToLast(WorldPosition value) { return value == lastValue; };
 
-        WorldPosition Calculate() { return value; }
+        WorldPosition Calculate() { return this->value; }
     };
 
     class RTSCSelectedValue : public ManualSetValue<bool>

--- a/playerbot/strategy/values/VendorValues.cpp
+++ b/playerbot/strategy/values/VendorValues.cpp
@@ -1,12 +1,13 @@
 #include "VendorValues.h"
 #include "ItemUsageValue.h"
 #include "BudgetValues.h"
+#include "../../PlayerbotAI.h"
 
 using namespace ai;
 
 bool VendorHasUsefulItemValue::Calculate()
 {
-    uint32 entry = stoi(getQualifier());
+    uint32 entry = stoi(this->getQualifier());
     static CreatureInfo const* cInfo = sObjectMgr.GetCreatureTemplate(entry);
 
     if (!cInfo)

--- a/playerbot/strategy/values/VendorValues.h
+++ b/playerbot/strategy/values/VendorValues.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include "../Value.h"
+#include "../NamedObjectContext.h"
+
+class PlayerbotAI;
+
 namespace ai
 {      
     class VendorHasUsefulItemValue : public BoolCalculatedValue, public Qualified


### PR DESCRIPTION
Imbue actions are broken on Linux, but I didn't have time to look into it yet. They can be disabled for Linux specifically using this commit: https://github.com/Exxenoz/mangosbot-bots/commit/9c7c727f01116230341d7847b2a510bbf390f896

```
Error: signal 11:
./mangosd(_Z7handleri+0x30)[0x55efcac52b70]
/lib/x86_64-linux-gnu/libc.so.6(+0x43090)[0x7f0042d1a090]
./mangosd(_ZNK6Object14GetUInt32ValueEt+0x24)[0x55efcacc9084]
./mangosd(_ZN2ai20ImbueWithStoneAction7ExecuteENS_5EventE+0x128)[0x55efcba29a08]
./mangosd(_ZN2ai6Engine16ListenAndExecuteEPNS_6ActionENS_5EventE+0x74c)[0x55efcb98d42c]
./mangosd(_ZN2ai6Engine12DoNextActionEP4Unitib+0xbd0)[0x55efcb98fcd0]
./mangosd(_ZN11PlayerbotAI12DoNextActionEb+0x11b)[0x55efcb81367b]
./mangosd(_ZN11PlayerbotAI16UpdateAIInternalEjb+0x774)[0x55efcb817a94]
./mangosd(_ZN11PlayerbotAI8UpdateAIEjb+0x3ac)[0x55efcb81222c]
./mangosd(_ZN6Player8UpdateAIEjb+0x24)[0x55efcadaf224]
terminate called after throwing an instance of 'std::runtime_error'
  what():  Dead Reference
Aborted

Attempt get value from nonexistent value field: 74 (count: 0) for object typeid: 0 type mask: 0
/home/cmangos-wotlk-playerbots/src/game/Entities/Object.h:493: Error: Assertion in GetByteValue failed: index < m_valuesCount || PrintIndexError(index, false)Error: signal 11:
./mangosd(_Z7handleri+0x30)[0x56329833ab70]
/lib/x86_64-linux-gnu/libc.so.6(+0x43090)[0x7f2ecd564090]
./mangosd(_ZN4Unit13SetStandStateEhb+0x33)[0x563298542653]
./mangosd(_ZN2ai18ImbueWithOilAction7ExecuteENS_5EventE+0x127)[0x563299111c77]
./mangosd(_ZN2ai6Engine16ListenAndExecuteEPNS_6ActionENS_5EventE+0x74c)[0x56329907542c]
./mangosd(_ZN2ai6Engine12DoNextActionEP4Unitib+0xbd0)[0x563299077cd0]
./mangosd(_ZN11PlayerbotAI12DoNextActionEb+0x11b)[0x563298efb67b]
./mangosd(_ZN11PlayerbotAI16UpdateAIInternalEjb+0x774)[0x563298effa94]
./mangosd(_ZN11PlayerbotAI8UpdateAIEjb+0x3ac)[0x563298efa22c]
./mangosd(_ZN6Player8UpdateAIEjb+0x24)[0x563298497224]
terminate called after throwing an instance of 'std::runtime_error'
  what():  Dead Reference
Aborted
```

I also encountered another crash in `weighted_shuffle` for cases where `accumulate(first_weight, last_weight, 0)` equals 0. Fix: https://github.com/Exxenoz/mangosbot-bots/commit/9e285f4a871c3380ae260970f8718576eff46f32