### PR TITLE
Always load area levels on startup

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -352,6 +352,9 @@ bool PlayerbotAIConfig::Initialize()
     targetPosRecalcDistance = config.GetFloatDefault("AiPlayerbot.TargetPosRecalcDistance", 0.1f),
     BarGoLink::SetOutputState(config.GetBoolDefault("AiPlayerbot.ShowProgressBars", false));
 
+    sLog.outString("Loading area levels.");
+    sTravelMgr.loadAreaLevels();
+
     RandomPlayerbotFactory::CreateRandomBots();
     PlayerbotFactory::Init();
     sRandomItemMgr.Init();

--- a/playerbot/TravelMgr.cpp
+++ b/playerbot/TravelMgr.cpp
@@ -2018,9 +2018,6 @@ void TravelMgr::LoadQuestTravelTable()
 
     }
 
-    sLog.outString("Loading area levels.");
-    loadAreaLevels();
-
     ObjectMgr::QuestMap const& questMap = sObjectMgr.GetQuestTemplates();
     vector<uint32> questIds;
 


### PR DESCRIPTION
Current behaviour: Area levels are only loaded on startup if the `AutoDoQuests` option is enabled. In case it is disabled, specific area levels will be calculated on the fly during runtime, which can lead to annoying lag spikes. This can be solved by loading area levels always (without any condition) on startup.