### PR TITLE
Fix crash when trying to summon a bot by using a meeting stone in the TBC and WotLK expansion

### DIFF
--- a/playerbot/strategy/actions/UseMeetingStoneAction.cpp
+++ b/playerbot/strategy/actions/UseMeetingStoneAction.cpp
@@ -208,6 +208,9 @@ bool AcceptSummonAction::Execute(Event& event)
 
     WorldPacket response(CMSG_SUMMON_RESPONSE);
     response << summonerGuid;
+#if defined(MANGOSBOT_ONE) || defined(MANGOSBOT_TWO)
+    response << uint8(1);
+#endif
     bot->GetSession()->HandleSummonResponseOpcode(response);
     
     return true;


### PR DESCRIPTION
`CMSG_SUMMON_RESPONSE ` is missing the "agree" flag, which leads to an error when reading the packet content in `WorldSession::HandleSummonResponseOpcode`.