### PR TITLE
Replace LANG_NEUTRAL with LANG_UNIVERSAL

### DIFF
--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -274,7 +274,7 @@ private:
 public:	
     static string BotStateToString(BotState state);
 	string HandleRemoteCommand(string command);
-    void HandleCommand(uint32 type, const string& text, Player& fromPlayer, const uint32 lang = LANG_NEUTRAL);
+    void HandleCommand(uint32 type, const string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);
     void QueueChatResponse(uint8 msgtype, ObjectGuid guid1, ObjectGuid guid2, std::string message, std::string chanName, std::string name);
 	void HandleBotOutgoingPacket(const WorldPacket& packet);
     void HandleMasterIncomingPacket(const WorldPacket& packet);

--- a/playerbot/PlayerbotMgr.h
+++ b/playerbot/PlayerbotMgr.h
@@ -57,7 +57,7 @@ public:
     static bool HandlePlayerbotMgrCommand(ChatHandler* handler, char const* args);
     void HandleMasterIncomingPacket(const WorldPacket& packet);
     void HandleMasterOutgoingPacket(const WorldPacket& packet);
-    void HandleCommand(uint32 type, const string& text, uint32 lang = LANG_NEUTRAL);
+    void HandleCommand(uint32 type, const string& text, uint32 lang = LANG_UNIVERSAL);
     void OnPlayerLogin(Player* player);
     void CancelLogout();
 

--- a/playerbot/RandomPlayerbotMgr.h
+++ b/playerbot/RandomPlayerbotMgr.h
@@ -80,7 +80,7 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         void UpdateGearSpells(Player* bot);
         void ScheduleTeleport(uint32 bot, uint32 time = 0);
         void ScheduleChangeStrategy(uint32 bot, uint32 time = 0);
-        void HandleCommand(uint32 type, const string& text, Player& fromPlayer, string channelName = "", Team team = TEAM_BOTH_ALLOWED, uint32 lang = LANG_NEUTRAL);
+        void HandleCommand(uint32 type, const string& text, Player& fromPlayer, string channelName = "", Team team = TEAM_BOTH_ALLOWED, uint32 lang = LANG_UNIVERSAL);
         string HandleRemoteCommand(string request);
         void OnPlayerLogout(Player* player);
         void OnPlayerLogin(Player* player);


### PR DESCRIPTION
`LANG_NEUTRAL` is some windows specific preprocessor constant that is not available on Linux. We should use `LANG_UNIVERSAL` (defined in SharedDefines.h) instead:

```
enum Language
{
    LANG_UNIVERSAL      = 0,
    LANG_ORCISH         = 1,
    LANG_DARNASSIAN     = 2,
    LANG_TAURAHE        = 3,
    LANG_DWARVISH       = 6,
    LANG_COMMON         = 7,
    LANG_DEMONIC        = 8,
    LANG_TITAN          = 9,
    LANG_THALASSIAN     = 10,
    LANG_DRACONIC       = 11,
    LANG_KALIMAG        = 12,
    LANG_GNOMISH        = 13,
    LANG_TROLL          = 14,
    LANG_GUTTERSPEAK    = 33,
    LANG_DRAENEI        = 35,
    LANG_ZOMBIE         = 36,
    LANG_GNOMISH_BINARY = 37,
    LANG_GOBLIN_BINARY  = 38,
    LANG_ADDON          = 0xFFFFFFFF
};
```