### PR TITLE
The attackers value will now check for group member attackers

### DIFF
--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -116,12 +116,6 @@ bool AttackAction::IsTargetValid(Unit* target)
         if (verbose) ai->TellError(msg.str());
         return false;
     }
-    else if (!sServerFacade.IsWithinLOSInMap(bot, target))
-    {
-        msg << " is not on my sight";
-        if (verbose) ai->TellError(msg.str());
-        return false;
-    }
     else if (sServerFacade.UnitIsDead(target))
     {
         msg << " is dead";

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -180,7 +180,15 @@ bool CastShootAction::isPossible()
 {
     // Check if the bot has a ranged weapon equipped
     UpdateWeaponInfo();
-    return rangedWeapon != nullptr;
+    if (rangedWeapon == nullptr)
+        return false;
+
+    // Check if the target exist and it can be shot
+    Unit* target = GetTarget();
+    if (!target || !sServerFacade.IsWithinLOSInMap(bot, target))
+        return false;
+
+    return true;
 }
 
 bool CastShootAction::Execute(Event& event)

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -1731,6 +1731,10 @@ bool SetBehindTargetAction::isUseful()
     if (!target)
         return false;
 
+    // Do not move if stay strategy is set
+    if(ai->HasStrategy("stay", BotState::BOT_STATE_NON_COMBAT))
+        return false;
+
     return !bot->IsFacingTargetsBack(target);
 }
 

--- a/playerbot/strategy/actions/ReachTargetActions.h
+++ b/playerbot/strategy/actions/ReachTargetActions.h
@@ -50,8 +50,12 @@ namespace ai
 
         virtual bool isUseful()
 		{
-            // do not move while casting
+            // Do not move while casting
             if (bot->IsNonMeleeSpellCasted(true))
+                return false;
+
+            // Do not move if stay strategy is set
+            if(ai->HasStrategy("stay", BotState::BOT_STATE_NON_COMBAT))
                 return false;
 
             return true;

--- a/playerbot/strategy/generic/CombatStrategy.cpp
+++ b/playerbot/strategy/generic/CombatStrategy.cpp
@@ -81,7 +81,6 @@ void WaitForAttackStrategy::InitTriggers(std::list<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode(
         "wait for attack safe distance",
         NextAction::array(0, new NextAction("wait for attack keep safe distance", 60.0f), NULL)));
-
 }
 
 void WaitForAttackStrategy::InitMultipliers(std::list<Multiplier*>& multipliers)

--- a/playerbot/strategy/triggers/RangeTriggers.h
+++ b/playerbot/strategy/triggers/RangeTriggers.h
@@ -282,14 +282,18 @@ namespace ai
         {
             if (WaitForAttackStrategy::ShouldWait(ai))
             {
-                Unit* target = AI_VALUE(Unit*, "current target");
-                if(target)
+                // Do not move if stay strategy is set
+                if (!ai->HasStrategy("stay", BotState::BOT_STATE_NON_COMBAT))
                 {
-                    const float safeDistance = WaitForAttackStrategy::GetSafeDistance();
-                    const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
-                    const float distanceToTarget = sServerFacade.GetDistance2d(ai->GetBot(), target);
-                    return (distanceToTarget > (safeDistance + safeDistanceThreshold)) ||
-                           (distanceToTarget < (safeDistance - safeDistanceThreshold));
+                    Unit* target = AI_VALUE(Unit*, "current target");
+                    if (target)
+                    {
+                        const float safeDistance = WaitForAttackStrategy::GetSafeDistance();
+                        const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
+                        const float distanceToTarget = sServerFacade.GetDistance2d(ai->GetBot(), target);
+                        return (distanceToTarget > (safeDistance + safeDistanceThreshold)) ||
+                               (distanceToTarget < (safeDistance - safeDistanceThreshold));
+                    }
                 }
             }
 

--- a/playerbot/strategy/values/AttackersValue.cpp
+++ b/playerbot/strategy/values/AttackersValue.cpp
@@ -1,6 +1,7 @@
 #include "botpch.h"
 #include "../../playerbot.h"
 #include "AttackersValue.h"
+#include "PossibleTargetsValue.h"
 
 #include "../../ServerFacade.h"
 #include "GridNotifiers.h"
@@ -66,34 +67,23 @@ void AttackersValue::AddAttackersOf(Player* player, set<Unit*>& targets)
         return;
 
 	list<Unit*> units;
-	//MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(player, sPlayerbotAIConfig.sightDistance);
-    //MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(units, u_check);
-    //Cell::VisitAllObjects(player, searcher, sPlayerbotAIConfig.sightDistance);
-
-    list<ObjectGuid> unitGuids = AI_VALUE(list<ObjectGuid>, "possible targets");
-
-    for (auto unitGuid : unitGuids)
-    {
-        Unit* unit = ai->GetUnit(unitGuid);
-        if (unit)
-            units.push_back(unit);
-    }
-
+    PossibleTargetsValue::FindPossibleTargets(player, units, sPlayerbotAIConfig.sightDistance);
 	for (list<Unit*>::iterator i = units.begin(); i != units.end(); i++)
     {
-		if (!player->GetGroup())
-		{
-			Unit* unit = *i;
+        Unit* unit = *i;
+        if (PossibleTargetsValue::IsValid(player, unit, sPlayerbotAIConfig.sightDistance))
+        {
+            if (!player->GetGroup())
+            {
 #ifdef CMANGOS
-			if (!unit->getThreatManager().getThreat(player) && (!unit->getThreatManager().getCurrentVictim() || unit->getThreatManager().getCurrentVictim()->getTarget() != player))
+                if (!unit->getThreatManager().getThreat(player) && (!unit->getThreatManager().getCurrentVictim() || unit->getThreatManager().getCurrentVictim()->getTarget() != player))
 #endif
 #ifdef MANGOS
-			if (!unit->GetThreatManager().getThreat(player))
+                if (!unit->GetThreatManager().getThreat(player))
 #endif
-				continue;
-		}
-        {
-            Unit* unit = *i;
+                    continue;
+            }
+
             targets.insert(unit);
             unit->CallForAllControlledUnits(AddGuardiansHelper(units), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM | CONTROLLED_MINIPET | CONTROLLED_TOTEMS);
         }
@@ -116,64 +106,98 @@ void AttackersValue::RemoveNonThreating(set<Unit*>& targets)
     }
 }
 
-bool AttackersValue::IsPossibleTarget(Unit *attacker, Player *bot, float range)
+bool AttackersValue::IsPossibleTarget(Unit *attacker, Player *player, float range)
 {
+    if(!attacker)
+        return false;
+
     Creature *c = dynamic_cast<Creature*>(attacker);
+    Group* group = player->GetGroup();
+    Player* master = nullptr;
 
     bool rti = false;
-    if (attacker && bot->GetGroup())
-        rti = bot->GetGroup()->GetTargetIcon(7) == attacker->GetObjectGuid();
-
-    PlayerbotAI* ai = bot->GetPlayerbotAI();
-    
     bool leaderHasThreat = false;
-    if (attacker && bot->GetGroup() && ai->GetMaster())
-        leaderHasThreat = attacker->getThreatManager().getThreat(ai->GetMaster());
-
     bool isMemberBotGroup = false;
-    if (bot->GetGroup() && ai->GetMaster() && ai->GetMaster()->GetPlayerbotAI() && !ai->GetMaster()->GetPlayerbotAI()->IsRealPlayer())
-        isMemberBotGroup = true;
+    bool inVehicle = false;
+    bool hasEnemyPlayerTarget = false;
+    bool inDuel = false;
+    bool canSeeAttacker = false;
+    bool hasShackleUndeadAura = false;
+    bool hasAttackTaggedStrategy = false;
+    bool isSapped = false;
+    bool isGouged = false;
+    bool isStunned = false;
+    bool isPolymorphed = false;
+    bool isFeared = false;
+    bool isFriendly = false;
+    bool isDead = false;
 
-    bool inCannon = ai->IsInVehicle(false, true);
+    // If the player is a bot
+    PlayerbotAI* bot = player->GetPlayerbotAI();
+    if(bot)
+    {
+        master = bot->GetMaster();
+        if (master)
+        {
+            if(group)
+            {
+                leaderHasThreat = attacker->getThreatManager().getThreat(master);
 
-    bool enemy = ai->GetAiObjectContext()->GetValue<Unit*>("enemy player target")->Get();
-    bool duel = false;
-    if (attacker && bot->duel && bot->duel->opponent && attacker->GetObjectGuid() == bot->duel->opponent->GetObjectGuid())
-        duel = true;
+                // If the master is a bot
+                if (master->GetPlayerbotAI() && !master->GetPlayerbotAI()->IsRealPlayer())
+                    isMemberBotGroup = true;
+            }
+        }
+
+        inVehicle = bot->IsInVehicle(false, true);
+        hasEnemyPlayerTarget = bot->GetAiObjectContext()->GetValue<Unit*>("enemy player target")->Get();
+        hasAttackTaggedStrategy = bot->HasStrategy("attack tagged", BotState::BOT_STATE_NON_COMBAT);
+        isSapped = bot->HasAura("sap", attacker);
+        isGouged = bot->HasAura("gouge", attacker);
+        hasShackleUndeadAura = bot->HasAura("shackle undead", attacker);
+    }
+
+    isStunned = attacker->IsStunned();
+    isPolymorphed = attacker->IsPolymorphed();
+    isFeared = sServerFacade.IsFeared(attacker);
+    isDead = sServerFacade.UnitIsDead(attacker);
+    isFriendly = sServerFacade.IsFriendlyTo(attacker, player);
+    inDuel = player->duel && player->duel->opponent && (attacker->GetObjectGuid() == player->duel->opponent->GetObjectGuid());
+    canSeeAttacker = attacker->IsVisibleForOrDetect(player, player->GetCamera().GetBody(), true);
+    rti = group && (group->GetTargetIcon(7) == attacker->GetObjectGuid());
 
 #ifndef MANGOSBOT_ZERO
     Player* arenaEnemy = dynamic_cast<Player*>(attacker);
     if (arenaEnemy)
     {
-        if (arenaEnemy->InArena() && bot->InArena() && arenaEnemy->GetBGTeam() != bot->GetBGTeam())
-            duel = true;
+        if (arenaEnemy->InArena() && player->InArena() && (arenaEnemy->GetBGTeam() != player->GetBGTeam()))
+            inDuel = true;
     }
 #endif
 
-    return attacker &&
-        attacker->IsInWorld() &&
-        attacker->GetMapId() == bot->GetMapId() &&
-        !sServerFacade.UnitIsDead(attacker) &&
+    return attacker->IsInWorld() &&
+        (attacker->GetMapId() == player->GetMapId()) &&
+        !isDead &&
         !attacker->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_1) &&
         !attacker->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNTARGETABLE) &&
-        (inCannon || !attacker->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE)) &&
-        attacker->IsVisibleForOrDetect(bot, bot->GetCamera().GetBody(), true) &&
+        (inVehicle || !attacker->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE)) &&
+        canSeeAttacker &&
 #ifdef CMANGOS
-        !(attacker->IsStunned() && ai->HasAura("shackle undead", attacker)) &&
-        !ai->HasAura("gouge", attacker) &&
+        !(isStunned && hasShackleUndeadAura) &&
+        !isGouged &&
 #endif
 #ifdef MANGOS
         //!attacker->hasUnitState(UNIT_STAT_STUNNED) &&
 #endif
-        !((attacker->IsPolymorphed() ||
-        bot->GetPlayerbotAI()->HasAura("sap", attacker) ||
+        !((isPolymorphed ||
+        isSapped ||
         //sServerFacade.IsCharmed(attacker) ||
-        sServerFacade.IsFeared(attacker)) && !rti) &&
+        isFeared) && !rti) &&
         //!sServerFacade.IsInRoots(attacker) &&
-        (!sServerFacade.IsFriendlyTo(attacker, bot) || duel) &&
-        bot->IsWithinDistInMap(attacker, range) &&
+        (!isFriendly || inDuel) &&
+        player->IsWithinDistInMap(attacker, range) &&
         !attacker->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION) &&
-        !(attacker->GetObjectGuid().IsPet() && enemy) &&
+        !(attacker->GetObjectGuid().IsPet() && hasEnemyPlayerTarget) &&
         !(attacker->GetCreatureType() == CREATURE_TYPE_CRITTER && !attacker->IsInCombat()) &&
         !(sPlayerbotAIConfig.IsInPvpProhibitedZone(sServerFacade.GetAreaId(attacker)) && (attacker->GetObjectGuid().IsPlayer() || attacker->GetObjectGuid().IsPet())) &&
         (!c || (
@@ -185,29 +209,28 @@ bool AttackersValue::IsPossibleTarget(Unit *attacker, Player *bot, float range)
 #endif
             (
 #ifdef CMANGOS
-                (!isMemberBotGroup && ai->HasStrategy("attack tagged", BotState::BOT_STATE_NON_COMBAT)) || leaderHasThreat ||
+                (!isMemberBotGroup && hasAttackTaggedStrategy) || leaderHasThreat ||
                 (!c->HasLootRecipient() &&
                     (!c->GetVictim() ||
                     c->GetVictim() &&
-                    ((bot->IsInGroup(c->GetVictim())) ||
-                        (ai->GetMaster() &&
-                            c->GetVictim() == ai->GetMaster())))) ||
-                c->IsTappedBy(bot)
+                    ((player->IsInGroup(c->GetVictim())) ||
+                        (master && c->GetVictim() == master)))) ||
+                c->IsTappedBy(player)
 #endif
 #ifndef MANGOSBOT_TWO
 #ifdef MANGOS
-                !attacker->HasFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED) || bot->IsTappedByMeOrMyGroup(c)
+                !attacker->HasFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED) || player->IsTappedByMeOrMyGroup(c)
 #endif
 #endif
                 )
             )
-            );
+        );
 }
 
 bool AttackersValue::IsValidTarget(Unit *attacker, Player *bot)
 {
     return  IsPossibleTarget(attacker, bot) &&
-        (sServerFacade.GetThreatManager(attacker).getCurrentVictim() ||
+            (sServerFacade.GetThreatManager(attacker).getCurrentVictim() ||
             attacker->GetGuidValue(UNIT_FIELD_TARGET) || attacker->GetObjectGuid().IsPlayer() ||
             attacker->GetObjectGuid() == bot->GetPlayerbotAI()->GetAiObjectContext()->GetValue<ObjectGuid>("pull target")->Get());
 }

--- a/playerbot/strategy/values/AttackersValue.h
+++ b/playerbot/strategy/values/AttackersValue.h
@@ -17,8 +17,8 @@ namespace ai
 		void RemoveNonThreating(set<Unit*>& targets);
 
     public:
-        static bool IsPossibleTarget(Unit* attacker, Player *bot, float range = sPlayerbotAIConfig.sightDistance);
-        static bool IsValidTarget(Unit* attacker, Player *bot);
+        static bool IsPossibleTarget(Unit* attacker, Player *player, float range = sPlayerbotAIConfig.sightDistance);
+        static bool IsValidTarget(Unit* attacker, Player *player);
     };
 
     class PossibleAddsValue : public BoolCalculatedValue

--- a/playerbot/strategy/values/PossibleTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleTargetsValue.cpp
@@ -13,9 +13,7 @@ using namespace MaNGOS;
 
 void PossibleTargetsValue::FindUnits(list<Unit*> &targets)
 {
-    MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(bot, range);
-    MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
-    Cell::VisitAllObjects(bot, searcher, range);
+    FindPossibleTargets(bot, targets, range);
 }
 
 bool PossibleTargetsValue::AcceptUnit(Unit* unit)
@@ -31,5 +29,17 @@ bool PossibleTargetsValue::AcceptUnit(Unit* unit)
     if (!isCCtarget && bot->getClass() == CLASS_WARLOCK && ai->HasMyAura("banish", unit))
         isCCtarget = true;
 
-    return isCCtarget || AttackersValue::IsPossibleTarget(unit, bot, range);
+    return isCCtarget || PossibleTargetsValue::IsValid(bot, unit, range);
+}
+
+void PossibleTargetsValue::FindPossibleTargets(Player* player, list<Unit*>& targets, float range)
+{
+    MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(player, range);
+    MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+    Cell::VisitAllObjects(player, searcher, range);
+}
+
+bool PossibleTargetsValue::IsValid(Player* player, Unit* target, float range)
+{
+    return AttackersValue::IsPossibleTarget(target, player, range);
 }

--- a/playerbot/strategy/values/PossibleTargetsValue.h
+++ b/playerbot/strategy/values/PossibleTargetsValue.h
@@ -11,16 +11,19 @@ namespace ai
         PossibleTargetsValue(PlayerbotAI* ai, string name = "possible targets", float range = sPlayerbotAIConfig.sightDistance, bool ignoreLos = false) :
           NearestUnitsValue(ai, name, range, ignoreLos) {}
 
+    public:
+        static void FindPossibleTargets(Player* player, list<Unit*>& targets, float range);
+        static bool IsValid(Player* player, Unit* target, float range);
+
     protected:
         virtual void FindUnits(list<Unit*> &targets);
         virtual bool AcceptUnit(Unit* unit);
-
 	};
 
     class AllTargetsValue : public PossibleTargetsValue
 	{
 	public:
         AllTargetsValue(PlayerbotAI* ai, float range = sPlayerbotAIConfig.sightDistance) :
-            PossibleTargetsValue(ai, "all targets", range, true) {}
+        PossibleTargetsValue(ai, "all targets", range, true) {}
 	};
 }


### PR DESCRIPTION
- Fix attackers value not considering player group members targets
- Prevent moving to target actions if the stay strategy is active
- Remove the LOS check from the attack action (a target not in LOS is still valid to be attacked and it should be handled by the next actions)
- Prevent shooting action if target not in LOS