### PR TITLE
Improve wait for attack keep safe distance and other fixes

### DIFF
--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -293,7 +293,7 @@ bool MovementAction::FlyDirect(WorldPosition &startPosition, WorldPosition &endP
 #endif
 }
 
-bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, bool react, bool noPath)
+bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, bool react, bool noPath, bool ignoreEnemyTargets)
 {
     WorldPosition endPosition(mapId, x, y, z, 0);
     if(!endPosition.isValid())
@@ -683,7 +683,8 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
         movePosition = movePath.getNextPoint(startPosition, maxDist, pathType, entry);
     }
 
-    if (!bot->IsInCombat() && !bot->IsDead()) //Stop the path when we might get aggro.
+    //Stop the path when we might get aggro.
+    if (!bot->IsInCombat() && !bot->IsDead() && !ignoreEnemyTargets) 
     {
         list<ObjectGuid> targets = AI_VALUE_LAZY(list<ObjectGuid>, "all targets");
 

--- a/playerbot/strategy/actions/MovementActions.h
+++ b/playerbot/strategy/actions/MovementActions.h
@@ -14,7 +14,7 @@ namespace ai
         bool ChaseTo(WorldObject *obj, float distance = 0.0f, float angle = 0.0f);
         bool MoveNear(uint32 mapId, float x, float y, float z, float distance = sPlayerbotAIConfig.contactDistance);
         bool FlyDirect(WorldPosition &startPosition,  WorldPosition &endPosition , WorldPosition& movePosition, TravelPath movePath, bool idle);
-        bool MoveTo(uint32 mapId, float x, float y, float z, bool idle = false, bool react = false, bool noPath = false);
+        bool MoveTo(uint32 mapId, float x, float y, float z, bool idle = false, bool react = false, bool noPath = false, bool ignoreEnemyTargets = false);
         bool MoveTo(Unit* target, float distance = 0.0f);
         bool MoveNear(WorldObject* target, float distance = sPlayerbotAIConfig.contactDistance);
         bool MoveToLOS(WorldObject* target, bool ranged = false);

--- a/playerbot/strategy/actions/ReachTargetActions.h
+++ b/playerbot/strategy/actions/ReachTargetActions.h
@@ -77,6 +77,10 @@ namespace ai
 
 		virtual bool isUseful()
 		{
+            // Do not move if stay strategy is set
+            if (ai->HasStrategy("stay", BotState::BOT_STATE_NON_COMBAT))
+                return false;
+
 			return sServerFacade.IsDistanceGreaterThan(AI_VALUE2(float, "distance", "current target"), (distance + sPlayerbotAIConfig.contactDistance));
 		}
 

--- a/playerbot/strategy/actions/WaitForAttackAction.cpp
+++ b/playerbot/strategy/actions/WaitForAttackAction.cpp
@@ -44,70 +44,96 @@ bool WaitForAttackKeepSafeDistanceAction::Execute(Event& event)
     Unit* target = AI_VALUE(Unit*, "current target");
     if (target)
     {
-        const Map* map = target->GetMap();
-        const WorldPosition botPosition(bot);
-        const WorldPosition targetPosition(target);
         const float safeDistance = WaitForAttackStrategy::GetSafeDistance();
         const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
 
         // Generate points around the target
         std::vector<WorldPosition> points;
-        const float angleIncrement = (10.0f / 180.0f) * (M_PI_F);
-        for (float angle = 0.0f; angle < (2.0f * M_PI_F); angle += angleIncrement)
+        GeneratePointsAroundTarget(target, 10.0f, safeDistance, points);
+
+        // Filter and select the best point
+        const WorldPosition* bestPoint = GetBestPoint(target, (safeDistance - safeDistanceThreshold), points);
+        if (bestPoint)
         {
-            float x = targetPosition.getX() + safeDistance * cos(angle);
-            float y = targetPosition.getY() + safeDistance * sin(angle);
-            float z = targetPosition.getZ() + 1.0f;
+            // Move to the best point
+            return MoveTo(bestPoint->getMapId(), bestPoint->getX(), bestPoint->getY(), bestPoint->getZ(), false, false, false, true);
+        }
+    }
 
-            // Check walls and obstacles around the target
+    return false;
+}
+
+void WaitForAttackKeepSafeDistanceAction::GeneratePointsAroundTarget(Unit* target, float angleIncrement, float radius, std::vector<WorldPosition>& outPoints)
+{
+    outPoints.clear();
+    const Map* map = target->GetMap();
+    const WorldPosition botPosition(bot);
+    const WorldPosition targetPosition(target);
+    const float radiansIncrement = (angleIncrement / 180.0f) * (M_PI_F);
+
+    for (float angle = 0.0f; angle < (2.0f * M_PI_F); angle += radiansIncrement)
+    {
+        float x = targetPosition.getX() + radius * cos(angle);
+        float y = targetPosition.getY() + radius * sin(angle);
+        float z = targetPosition.getZ() + 1.0f;
+
+        // Check walls and obstacles around the target
 #ifndef MANGOSBOT_TWO
-            map->GetHitPosition(targetPosition.getX(), targetPosition.getY(), targetPosition.getZ() + 1.0f, x, y, z, -0.5f);
+        map->GetHitPosition(targetPosition.getX(), targetPosition.getY(), targetPosition.getZ() + 1.0f, x, y, z, -0.5f);
 #else
-            map->GetHitPosition(targetPosition.getX(), targetPosition.getY(), targetPosition.getZ() + 1.0f, x, y, z, bot->GetPhaseMask(), -0.5f);
+        map->GetHitPosition(targetPosition.getX(), targetPosition.getY(), targetPosition.getZ() + 1.0f, x, y, z, bot->GetPhaseMask(), -0.5f);
 #endif                       
-            // Reset z to original value to avoid too much difference from original point before GetHeightInRange
-            z = targetPosition.getZ();
+        // Reset z to original value to avoid too much difference from original point before GetHeightInRange
+        z = targetPosition.getZ();
 
-            // Get proper height coordinate
+        // Get proper height coordinate
 #ifndef MANGOSBOT_TWO
-            if (map->GetHeightInRange(x, y, z))
+        if (map->GetHeightInRange(x, y, z))
 #else
-            if (map->GetHeightInRange(bot->GetPhaseMask(), x, y, z))
+        if (map->GetHeightInRange(bot->GetPhaseMask(), x, y, z))
 #endif
+        {
+            // Project vector to get only positive value
+            const float ab = fabs(botPosition.getX() - x);
+            const float ac = fabs(botPosition.getZ() - z);
+
+            // Slope represented by c angle (in radian)
+            // 50 (degrees) max seem best value for walkable slope
+            const float MAX_SLOPE_IN_RADIAN = 50.0f / 180.0f * M_PI_F;
+
+            // Check ab vector to avoid divide by 0
+            if (ab > 0.0f)
             {
-                // Project vector to get only positive value
-                const float ab = fabs(botPosition.getX() - x);
-                const float ac = fabs(botPosition.getZ() - z);
-
-                // Slope represented by c angle (in radian)
-                // 50 (degrees) max seem best value for walkable slope
-                const float MAX_SLOPE_IN_RADIAN = 50.0f / 180.0f * M_PI_F;
-
-                // Check ab vector to avoid divide by 0
-                if (ab > 0.0f)
+                // Compute c angle and convert it from radians to degrees
+                const float slope = atan(ac / ab);
+                if (slope < MAX_SLOPE_IN_RADIAN)
                 {
-                    // Compute c angle and convert it from radians to degrees
-                    const float slope = atan(ac / ab);
-                    if (slope < MAX_SLOPE_IN_RADIAN)
-                    {
-                        points.push_back(WorldPosition(target->GetMapId(), x, y, z));
-                    }
+                    outPoints.push_back(WorldPosition(target->GetMapId(), x, y, z));
                 }
             }
         }
+    }
+}
 
-        if (!points.empty())
+const ai::WorldPosition* WaitForAttackKeepSafeDistanceAction::GetBestPoint(Unit* target, float safeDistance, const std::vector<WorldPosition>& points) const
+{
+    const WorldPosition* bestPoint = nullptr;
+    if (!points.empty())
+    {
+        const std::list<ObjectGuid> enemies = AI_VALUE(std::list<ObjectGuid>, "possible targets no los");
+
+        // Filter and select the best point
+        float bestDistance = 9999.0f;
+        for (const WorldPosition& point : points)
         {
-            // Filter and select the best point
-            float bestDistance = 9999.0f;
-            const WorldPosition* bestPoint = nullptr;
-            for (const WorldPosition& point : points)
+            // Check if the point is not too close to the target
+            if (target->GetDistance(point.getX(), point.getY(), point.getZ()) > safeDistance)
             {
-                // Check if the point is not too close to the target
-                if (target->GetDistance(point.getX(), point.getY(), point.getZ()) > (safeDistance - safeDistanceThreshold))
+                // Check if the target is visible from the point
+                if (target->IsWithinLOS(point.getX(), point.getY(), point.getZ() + bot->GetCollisionHeight()))
                 {
-                    // Check if the target is visible from the point
-                    if (target->IsWithinLOS(point.getX(), point.getY(), point.getZ() + bot->GetCollisionHeight()))
+                    // Check if the point is not surrounded by other enemies
+                    if (!IsEnemyClose(point, enemies))
                     {
                         const float distanceToPoint = sqrt(bot->GetDistance(point.getX(), point.getY(), point.getZ()));
                         if (distanceToPoint < bestDistance)
@@ -123,11 +149,32 @@ bool WaitForAttackKeepSafeDistanceAction::Execute(Event& event)
                     }
                 }
             }
+        }
+    }
 
-            if (bestPoint)
+    return bestPoint;
+}
+
+bool WaitForAttackKeepSafeDistanceAction::IsEnemyClose(const WorldPosition& point, const std::list<ObjectGuid>& enemies) const
+{
+    for (const ObjectGuid& enemyGUID : enemies)
+    {
+        Unit* enemy = ai->GetUnit(enemyGUID);
+        if (enemy)
+        {
+            // If the enemy is visible in the same map
+            if (enemy->IsWithinLOSInMap(bot))
             {
-                // Move to the best point
-                return MoveTo(bestPoint->getMapId(), bestPoint->getX(), bestPoint->getY(), bestPoint->getZ());
+                // If the enemy is not neutral
+                if (enemy->CanAttackOnSight(bot))
+                {
+                    const float enemyAttackRange = enemy->GetAttackDistance(bot) + ATTACK_DISTANCE;
+                    const float distanceToPoint = WorldPosition(enemy).sqDistance(point);
+                    if (distanceToPoint <= (enemyAttackRange * enemyAttackRange))
+                    {
+                        return true;
+                    }
+                }
             }
         }
     }

--- a/playerbot/strategy/actions/WaitForAttackAction.h
+++ b/playerbot/strategy/actions/WaitForAttackAction.h
@@ -18,5 +18,10 @@ namespace ai
    public:
        WaitForAttackKeepSafeDistanceAction(PlayerbotAI* ai) : MovementAction(ai, "wait for attack keep safe distance") {}
        virtual bool Execute(Event& event);
+
+   private:
+       void GeneratePointsAroundTarget(Unit* target, float angleIncrement, float radius, std::vector<WorldPosition>& outPoints);
+       const WorldPosition* GetBestPoint(Unit* target, float safeDistance, const std::vector<WorldPosition>& points) const;
+       bool IsEnemyClose(const WorldPosition& point, const std::list<ObjectGuid>& enemies) const;
    };
 }

--- a/playerbot/strategy/triggers/RangeTriggers.h
+++ b/playerbot/strategy/triggers/RangeTriggers.h
@@ -285,14 +285,19 @@ namespace ai
                 // Do not move if stay strategy is set
                 if (!ai->HasStrategy("stay", BotState::BOT_STATE_NON_COMBAT))
                 {
-                    Unit* target = AI_VALUE(Unit*, "current target");
-                    if (target)
+                    // Do not move if currently being targeted
+                    const bool isBeingTargeted = !bot->getAttackers().empty();
+                    if (!isBeingTargeted)
                     {
-                        const float safeDistance = WaitForAttackStrategy::GetSafeDistance();
-                        const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
-                        const float distanceToTarget = sServerFacade.GetDistance2d(ai->GetBot(), target);
-                        return (distanceToTarget > (safeDistance + safeDistanceThreshold)) ||
-                               (distanceToTarget < (safeDistance - safeDistanceThreshold));
+                        Unit* target = AI_VALUE(Unit*, "current target");
+                        if (target)
+                        {
+                            const float safeDistance = WaitForAttackStrategy::GetSafeDistance();
+                            const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
+                            const float distanceToTarget = sServerFacade.GetDistance2d(bot, target);
+                            return (distanceToTarget > (safeDistance + safeDistanceThreshold)) ||
+                                   (distanceToTarget < (safeDistance - safeDistanceThreshold));
+                        }
                     }
                 }
             }

--- a/playerbot/strategy/values/CombatTargetsValue.cpp
+++ b/playerbot/strategy/values/CombatTargetsValue.cpp
@@ -155,7 +155,9 @@ bool CombatTargetsValue::IsValid(Unit* target, Player* player) const
         else
         {
             // Check if the npc target is in combat with the player
-            const bool inCombatWithPlayer = target->getThreatManager().getThreat(player) > 0.0f;
+            const bool inCombatWithPlayer = (target->getThreatManager().getThreat(player) > 0.0f) ||
+                                            (target->GetVictim() && (target->GetVictim() == player));
+
             const bool isPlayerPet = target->GetObjectGuid().IsPet();
 
             const Creature* creature = dynamic_cast<Creature*>(target);


### PR DESCRIPTION
- Improve wait for attack keep safe distance to detect enemies nearby
- Don't trigger wait for attack keep safe distance if being targeted (to make the tanks life easier)
- Prevent doing reach actions (such as charge) if stay strategy is active
- Combat targets should consider the victims of the enemy target