### PR TITLE
Living bomb improvements

### DIFF
--- a/playerbot/strategy/mage/FireMageStrategy.cpp
+++ b/playerbot/strategy/mage/FireMageStrategy.cpp
@@ -26,10 +26,14 @@ void FireMageStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "enemy too close for spell",
         NextAction::array(0, new NextAction("dragon's breath", 61.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "living bomb",
+        NextAction::array(0, new NextAction("living bomb", 30.0f), NULL)));
 #endif
 
 #ifndef MANGOSBOT_TWO
-    triggers.push_back(new TriggerNode(
+    triggers.push_back(new TriggerNode
         "pyroblast",
         NextAction::array(0, new NextAction("pyroblast", 10.0f), NULL)));
 
@@ -65,13 +69,15 @@ void FireMageStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)
 
 void FireMageAoeStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)
 {
+#ifndef MANGOSBOT_ZERO
+    triggers.push_back(new TriggerNode(
+        "living bomb",
+        NextAction::array(0, new NextAction("living bomb", 30.0f), NULL)));
+#endif
+
     triggers.push_back(new TriggerNode(
         "medium aoe",
         NextAction::array(0, new NextAction("flamestrike", 20.0f), NULL)));
-
-    triggers.push_back(new TriggerNode(
-        "living bomb",
-        NextAction::array(0, new NextAction("living bomb", 25.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
         "fire spells on cooldown",

--- a/playerbot/strategy/mage/MageActions.h
+++ b/playerbot/strategy/mage/MageActions.h
@@ -199,12 +199,6 @@ namespace ai
 		CastSpellstealAction(PlayerbotAI* ai) : CastSpellAction(ai, "spellsteal") {}
 	};
 
-	class CastLivingBombAction : public CastRangedDebuffSpellAction
-	{
-	public:
-	    CastLivingBombAction(PlayerbotAI* ai) : CastRangedDebuffSpellAction(ai, "living bomb") {}
-	};
-
 	class CastInvisibilityAction : public CastBuffSpellAction
 	{
 	public:
@@ -267,6 +261,12 @@ namespace ai
     {
     public:
         CastBlastWaveAction(PlayerbotAI* ai) : CastMeleeAoeSpellAction(ai, "blast wave", 10.0f) {}
+    };
+
+    class CastLivingBombAction : public CastRangedDebuffSpellAction
+    {
+    public:
+        CastLivingBombAction(PlayerbotAI* ai) : CastRangedDebuffSpellAction(ai, "living bomb") {}
     };
 #endif
 

--- a/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -108,7 +108,6 @@ namespace ai
                 creators["polymorph"] = &TriggerFactoryInternal::polymorph;
                 creators["spellsteal"] = &TriggerFactoryInternal::spellsteal;
                 creators["no improved scorch"] = &TriggerFactoryInternal::no_improved_scorch;
-                creators["living bomb"] = &TriggerFactoryInternal::living_bomb;
                 creators["missile barrage"] = &TriggerFactoryInternal::missile_barrage;
                 creators["arcane blast"] = &TriggerFactoryInternal::arcane_blast;
                 creators["counterspell on enemy healer"] = &TriggerFactoryInternal::counterspell_enemy_healer;
@@ -127,6 +126,9 @@ namespace ai
                 creators["hot streak"] = &TriggerFactoryInternal::hot_streak;
                 creators["fireball!"] = &TriggerFactoryInternal::fireball_or_frostfire_bolt_free;
                 creators["finger of frost"] = &TriggerFactoryInternal::finger_of_frost;
+#endif
+#ifndef MANGOSBOT_ZERO
+                creators["living bomb"] = &TriggerFactoryInternal::living_bomb;
 #endif
             }
 
@@ -152,7 +154,6 @@ namespace ai
             static Trigger* counterspell(PlayerbotAI* ai) { return new CounterspellInterruptSpellTrigger(ai); }
             static Trigger* polymorph(PlayerbotAI* ai) { return new PolymorphTrigger(ai); }
             static Trigger* spellsteal(PlayerbotAI* ai) { return new SpellstealTrigger(ai); }
-            static Trigger* living_bomb(PlayerbotAI* ai) { return new LivingBombTrigger(ai); }
             static Trigger* missile_barrage(PlayerbotAI* ai) { return new MissileBarrageTrigger(ai); }
             static Trigger* arcane_blast(PlayerbotAI* ai) { return new ArcaneBlastTrigger(ai); }
             static Trigger* counterspell_enemy_healer(PlayerbotAI* ai) { return new CounterspellEnemyHealerTrigger(ai); }
@@ -163,6 +164,9 @@ namespace ai
             static Trigger* hot_streak(PlayerbotAI* ai) { return new HotStreakTrigger(ai); }
             static Trigger* fireball_or_frostfire_bolt_free(PlayerbotAI* ai) { return new FireballOrFrostfireBoltFreeTrigger(ai); }
             static Trigger* finger_of_frost(PlayerbotAI* ai) { return new FingersOfFrostTrigger(ai); }
+#endif
+#ifndef MANGOSBOT_ZERO
+            static Trigger* living_bomb(PlayerbotAI* ai) { return new LivingBombTrigger(ai); }
 #endif
         };
     };
@@ -208,7 +212,6 @@ namespace ai
                 creators["ice block"] = &AiObjectContextInternal::ice_block;
                 creators["polymorph"] = &AiObjectContextInternal::polymorph;
                 creators["spellsteal"] = &AiObjectContextInternal::spellsteal;
-                creators["living bomb"] = &AiObjectContextInternal::living_bomb;
                 creators["invisibility"] = &AiObjectContextInternal::invisibility;
                 creators["evocation"] = &AiObjectContextInternal::evocation;
                 creators["arcane blast"] = &AiObjectContextInternal::arcane_blast;
@@ -228,6 +231,7 @@ namespace ai
 #ifndef MANGOSBOT_ZERO
                 creators["dragon's breath"] = &AiObjectContextInternal::dragons_breath;
                 creators["blast wave"] = &AiObjectContextInternal::blast_wave;
+                creators["living bomb"] = &AiObjectContextInternal::living_bomb;
 #endif
 #ifdef MANGOSBOT_TWO
                 creators["frostfire bolt"] = &AiObjectContextInternal::frostfire_bolt;
@@ -276,7 +280,6 @@ namespace ai
             static Action* ice_block(PlayerbotAI* ai) { return new CastIceBlockAction(ai); }
             static Action* polymorph(PlayerbotAI* ai) { return new CastPolymorphAction(ai); }
             static Action* spellsteal(PlayerbotAI* ai) { return new CastSpellstealAction(ai); }
-            static Action* living_bomb(PlayerbotAI* ai) { return new CastLivingBombAction(ai); }
             static Action* invisibility(PlayerbotAI* ai) { return new CastInvisibilityAction(ai); }
             static Action* evocation(PlayerbotAI* ai) { return new CastEvocationAction(ai); }
             static Action* counterspell_on_enemy_healer(PlayerbotAI* ai) { return new CastCounterspellOnEnemyHealerAction(ai); }
@@ -284,6 +287,7 @@ namespace ai
 #ifndef MANGOSBOT_ZERO
             static Action* dragons_breath(PlayerbotAI* ai) { return new CastDragonsBreathAction(ai); }
             static Action* blast_wave(PlayerbotAI* ai) { return new CastBlastWaveAction(ai); }
+            static Action* living_bomb(PlayerbotAI* ai) { return new CastLivingBombAction(ai); }
 #endif
 #ifdef MANGOSBOT_TWO
             static Action* frostfire_bolt(PlayerbotAI* ai) { return new CastFrostfireBoltAction(ai); }

--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -37,11 +37,6 @@ namespace ai
         virtual bool IsActive();
     };
 
-    class LivingBombTrigger : public DebuffTrigger {
-    public:
-        LivingBombTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "living bomb") {}
-	};
-
     class FireballTrigger : public DebuffTrigger {
     public:
         FireballTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "fireball") {}
@@ -158,6 +153,11 @@ namespace ai
 #endif
 
 #ifndef MANGOSBOT_ZERO
+    class LivingBombTrigger : public DebuffTrigger {
+    public:
+        LivingBombTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "living bomb") {}
+    };
+
     class ColdSnapTrigger : public Trigger
     {
     public:


### PR DESCRIPTION
- Mage improvement: (WOTLK) For fire mage most important is casting Living Bomb instead of Hot Streak Pyroblast
- Mage improvement: Excluded Living Bomb from vanilla build
- Mage improvement: Included Living Bomb in "fire" strategy

![obraz](https://user-images.githubusercontent.com/28183654/231355592-88731109-77fd-4bf1-bf61-a2b019ff0384.png)
