### PR TITLE
Glyph of Molten Armor

### DIFF
--- a/playerbot/AiFactory.cpp
+++ b/playerbot/AiFactory.cpp
@@ -463,12 +463,16 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
             nonCombatEngine->addStrategies("dps assist", "cure", NULL);
             break;
         case CLASS_MAGE:
+#ifdef MANGOSBOT_TWO
+            nonCombatEngine->addStrategies("dps assist", "cure", "bdps", "bmana", NULL);
+#else
             if (tab == 1)
                 nonCombatEngine->addStrategy("bdps");
             else
                 nonCombatEngine->addStrategy("bmana");
 
             nonCombatEngine->addStrategies("dps assist", "cure", NULL);
+#endif
             break;
         case CLASS_DRUID:
             if (tab == 1)

--- a/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
+++ b/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
@@ -62,13 +62,23 @@ void GenericMageNonCombatStrategy::InitNonCombatTriggers(std::list<TriggerNode*>
    triggers.push_back(new TriggerNode(
       "often",
       NextAction::array(0, new NextAction("apply oil", 1.0f), NULL)));
+
+#ifdef MANGOSBOT_TWO
+   triggers.push_back(new TriggerNode(
+       "learn glyph of molten armor",
+       NextAction::array(0, new NextAction("learn glyph of molten armor", 20.0f), NULL)));
+
+   triggers.push_back(new TriggerNode(
+       "remove glyph of molten armor",
+       NextAction::array(0, new NextAction("remove glyph of molten armor", 20.0f), NULL)));
+#endif
 }
 
 void MageBuffManaStrategy::InitNonCombatTriggers(std::list<TriggerNode*> &triggers)
 {
     triggers.push_back(new TriggerNode(
         "mage armor",
-        NextAction::array(0, new NextAction("mage armor", 19.0f), NULL)));
+        NextAction::array(0, new NextAction("mage armor", 18.0f), NULL)));
 }
 
 void MageBuffManaStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/mage/MageActions.h
+++ b/playerbot/strategy/mage/MageActions.h
@@ -288,5 +288,37 @@ namespace ai
     public:
         MirrorImageAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "mirror image") {}
     };
+
+    class LearnGlyphOfMoltenArmorAction : public Action
+    {
+    public:
+        LearnGlyphOfMoltenArmorAction(PlayerbotAI* ai) : Action(ai, "learn glyph of molten armor") {}
+        virtual bool Execute(Event& event)
+        {
+            bot->learnSpell(42751, false);
+
+            ostringstream out;
+            out << "I learned Glyph of Molten Armor";
+            ai->TellError(out.str());
+
+            return true;
+        }
+    };
+
+    class RemoveGlyphOfMoltenArmorAction : public Action
+    {
+    public:
+        RemoveGlyphOfMoltenArmorAction(PlayerbotAI* ai) : Action(ai, "remove glyph of molten armor") {}
+        virtual bool Execute(Event& event)
+        {
+            bot->removeSpell(42751);
+
+            ostringstream out;
+            out << "I removed Glyph of Molten Armor";
+            ai->TellError(out.str());
+
+            return true;
+        }
+    };
 #endif
 }

--- a/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -127,6 +127,8 @@ namespace ai
                 creators["fireball!"] = &TriggerFactoryInternal::fireball_or_frostfire_bolt_free;
                 creators["finger of frost"] = &TriggerFactoryInternal::finger_of_frost;
                 creators["mirror image"] = &TriggerFactoryInternal::mirror_image;
+                creators["learn glyph of molten armor"] = &TriggerFactoryInternal::learn_glyph_of_molten_armor;
+                creators["remove glyph of molten armor"] = &TriggerFactoryInternal::remove_glyph_of_molten_armor;
 #endif
 #ifndef MANGOSBOT_ZERO
                 creators["living bomb"] = &TriggerFactoryInternal::living_bomb;
@@ -166,6 +168,8 @@ namespace ai
             static Trigger* fireball_or_frostfire_bolt_free(PlayerbotAI* ai) { return new FireballOrFrostfireBoltFreeTrigger(ai); }
             static Trigger* finger_of_frost(PlayerbotAI* ai) { return new FingersOfFrostTrigger(ai); }
             static Trigger* mirror_image(PlayerbotAI* ai) { return new MirrorImageTrigger(ai); }
+            static Trigger* learn_glyph_of_molten_armor(PlayerbotAI* ai) { return new LearnGlyphOfMoltenArmorTrigger(ai); }
+            static Trigger* remove_glyph_of_molten_armor(PlayerbotAI* ai) { return new RemoveGlyphOfMoltenArmorTrigger(ai); }
 #endif
 #ifndef MANGOSBOT_ZERO
             static Trigger* living_bomb(PlayerbotAI* ai) { return new LivingBombTrigger(ai); }
@@ -239,6 +243,8 @@ namespace ai
                 creators["frostfire bolt"] = &AiObjectContextInternal::frostfire_bolt;
                 creators["deep freeze"] = &AiObjectContextInternal::deep_freeze;
                 creators["mirror image"] = &AiObjectContextInternal::mirror_image;
+                creators["learn glyph of molten armor"] = &AiObjectContextInternal::learn_glyph_of_molten_armor;
+                creators["remove glyph of molten armor"] = &AiObjectContextInternal::remove_glyph_of_molten_armor;
 #endif
             }
 
@@ -296,6 +302,8 @@ namespace ai
             static Action* frostfire_bolt(PlayerbotAI* ai) { return new CastFrostfireBoltAction(ai); }
             static Action* deep_freeze(PlayerbotAI* ai) { return new DeepFreezeAction(ai); }
             static Action* mirror_image(PlayerbotAI* ai) { return new MirrorImageAction(ai); }
+            static Action* learn_glyph_of_molten_armor(PlayerbotAI* ai) { return new LearnGlyphOfMoltenArmorAction(ai); }
+            static Action* remove_glyph_of_molten_armor(PlayerbotAI* ai) { return new RemoveGlyphOfMoltenArmorAction(ai); }
 #endif
         };
     };

--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../triggers/GenericTriggers.h"
+#include "../triggers/GlyphTriggers.h"
 
 namespace ai
 {
@@ -151,6 +152,31 @@ namespace ai
     BUFF_TRIGGER_A(HotStreakTrigger, "hot streak");
     BUFF_TRIGGER_A(FireballOrFrostfireBoltFreeTrigger, "fireball!");
     HAS_AURA_TRIGGER(FingersOfFrostTrigger, "fingers of frost");
+
+    class LearnGlyphOfMoltenArmorTrigger : public LearnGlyphTrigger
+    {
+    public:
+        LearnGlyphOfMoltenArmorTrigger(PlayerbotAI* ai) : LearnGlyphTrigger(ai,
+            "learn glyph of molten armor", 
+            42751,                          //Glyph of Molten Armor
+            30482,                          //Required Molten Armor Rank 1
+            62,                             //Required 62 lvl
+            ""                              //No strategy required
+            ) {}
+    };
+
+    class RemoveGlyphOfMoltenArmorTrigger : public RemoveGlyphTrigger
+    {
+    public:
+        RemoveGlyphOfMoltenArmorTrigger(PlayerbotAI* ai) : RemoveGlyphTrigger(ai,
+            "remove glyph of molten armor",
+            42751,                          //Glyph of Molten Armor
+            30482,                          //Required Molten Armor Rank 1
+            62,                             //Required 62 lvl
+            ""                              //No strategy required
+        ) {}
+    };
+
 #endif
 
 #ifndef MANGOSBOT_ZERO

--- a/playerbot/strategy/triggers/GlyphTriggers.h
+++ b/playerbot/strategy/triggers/GlyphTriggers.h
@@ -1,0 +1,69 @@
+#pragma once
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "../Trigger.h"
+
+namespace ai
+{
+    class LearnGlyphTrigger : public Trigger
+    {
+    public:
+        LearnGlyphTrigger(PlayerbotAI* ai, string triggerName, int glyphId, int requiredSpellId = -1, int requiredLevel = -1, string requiredCombatStrategy = "") : Trigger(ai, triggerName, 60) {
+            this->glyphId = glyphId;
+            this->requiredSpellId = requiredSpellId;
+            this->requiredLevel = requiredLevel;
+            this->requiredCombatStrategy = requiredCombatStrategy;
+        }
+        virtual bool IsActive()
+        {
+            if (glyphId == 0 || bot->HasSpell(glyphId))
+                return false;
+
+            if (requiredSpellId != -1 && !bot->HasSpell(requiredSpellId))
+                return false;
+
+            if (requiredLevel != -1 && bot->GetLevel() < requiredLevel)
+                return false;
+
+            if (!requiredCombatStrategy.empty() && !ai->HasStrategy(requiredCombatStrategy, BotState::BOT_STATE_COMBAT))
+                return false;
+
+            return true;
+        }
+
+    private:
+        int glyphId, requiredSpellId, requiredLevel;
+        string requiredCombatStrategy;
+    };
+
+    class RemoveGlyphTrigger : public Trigger
+    {
+    public:
+        RemoveGlyphTrigger(PlayerbotAI* ai, string triggerName, int glyphId, int requiredSpellId = -1, int requiredLevel = -1, string requiredCombatStrategy = "") : Trigger(ai, triggerName, 60) {
+            this->glyphId = glyphId;
+            this->requiredSpellId = requiredSpellId;
+            this->requiredLevel = requiredLevel;
+            this->requiredCombatStrategy = requiredCombatStrategy;
+        }
+        virtual bool IsActive()
+        {
+            if (glyphId == 0 || !bot->HasSpell(glyphId))
+                return false;
+
+            if (requiredSpellId != -1 && !bot->HasSpell(requiredSpellId))
+                return true;
+
+            if (requiredLevel != -1 && bot->GetLevel() < requiredLevel)
+                return true;
+
+            if (!requiredCombatStrategy.empty() && !ai->HasStrategy(requiredCombatStrategy, BotState::BOT_STATE_COMBAT))
+                return true;
+
+            return false;
+        }
+
+    private:
+        int glyphId, requiredSpellId, requiredLevel;
+        string requiredCombatStrategy;
+    };
+}


### PR DESCRIPTION
- Mage improvement: (WOTLK) Mage now learn Glyph of Molten Armor when meet requirements
- Mage improvement: (WOTLK) Mage now uses Molten Armor instead of Mage Armor

![obraz](https://user-images.githubusercontent.com/28183654/231870371-e084812f-81ae-4bac-985e-6689274940e3.png)
![obraz](https://user-images.githubusercontent.com/28183654/231870416-c2b2a5c7-67a7-4462-b2a3-2dbd9561da00.png)