### PR TITLE
…

### DIFF
--- a/playerbot/AiFactory.cpp
+++ b/playerbot/AiFactory.cpp
@@ -231,7 +231,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             else
                 engine->addStrategies("frost", "frost aoe", "threat", NULL);
 
-            engine->addStrategies("dps", "dps assist", "flee", "cure", "ranged", "cc", NULL);
+            engine->addStrategies("dps", "dps assist", "flee", "cure", "ranged", "cc", "boost", NULL);
             break;
         case CLASS_WARRIOR:
             if (tab == 2)

--- a/playerbot/strategy/mage/GenericMageStrategy.cpp
+++ b/playerbot/strategy/mage/GenericMageStrategy.cpp
@@ -206,7 +206,7 @@ void MageBoostStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)
 #ifdef MANGOSBOT_TWO
     triggers.push_back(new TriggerNode(
         "mirror image",
-        NextAction::array(0, new NextAction("mirror image", 43.0f), NULL)));
+        NextAction::array(0, new NextAction("mirror image", 59.0f), NULL)));
 #endif
 }
 


### PR DESCRIPTION
- Mage improvement: (WOTLK) Mage now cast Mirror Image to slow enemy (and confuse in pvp) and then start to flee if its too close.
- Mage improvement: Mage now have boost strategy as default


Additionally that fix fire mage behavior when he run out too far for mirror image frostbolt because his fireball spell have higher range.