### PR TITLE
Mana tap

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -3792,6 +3792,7 @@ bool PlayerbotAI::canDispel(const SpellEntry* entry, uint32 dispelType)
         strcmpi((const char*)entry->SpellName[0], "frost armor") &&
         strcmpi((const char*)entry->SpellName[0], "wavering will") &&
         strcmpi((const char*)entry->SpellName[0], "chilled") &&
+        strcmpi((const char*)entry->SpellName[0], "mana tap") &&
         strcmpi((const char*)entry->SpellName[0], "ice armor"));
 }
 


### PR DESCRIPTION
- Buff fix: Bots no longer try to dispel mana tap

![obraz](https://github.com/celguar/mangosbot-bots/assets/28183654/4db46ffc-d0e1-4ac4-9d3f-2f164af65649)
Mana tap is positive spell which cant be dispelled by friendly healer