### PR TITLE
Trade spam fix

### DIFF
--- a/playerbot/ChatHelper.cpp
+++ b/playerbot/ChatHelper.cpp
@@ -664,8 +664,8 @@ bool ChatHelper::parseable(string text)
             substrContainsInMap<uint32>(text, consumableSubClasses) ||
             substrContainsInMap<uint32>(text, tradeSubClasses) ||
             substrContainsInMap<uint32>(text, itemQualities) ||
-            substrContainsInMap<uint32>(text, slots) ||
-            substrContainsInMap<ChatMsg>(text, chats) ||
+            (substrContainsInMap<uint32>(text, slots) && text.find("rtsc ") == string::npos) ||
+            (substrContainsInMap<ChatMsg>(text, chats) && text.find(" on party") == string::npos) ||
             substrContainsInMap<uint32>(text, skills) ||
             parseMoney(text) > 0;
 }


### PR DESCRIPTION
-Trade fix: Bot no longer trade when master call do action on party or rtsc ranged command