### PR TITLE
- Buff fix: Shaman no longer cast Earth Shield in loop between tanks

### DIFF
--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -496,7 +496,7 @@ namespace ai
                 }
             }
 
-            return BuffOnTankTrigger::IsActive() && !someoneHaveOwnerAura;
+            return BuffOnTankTrigger::IsActive();
         }
     };
 }

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -483,5 +483,24 @@ namespace ai
     {
     public:
         PartyTankEarthShieldTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "earth shield") {}
+
+        virtual bool IsActive()
+        {
+            bool someoneHaveOwnerAura = false;
+            Group* group = bot->GetGroup();
+            if (group)
+            {
+                for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+                {
+                    if (ai->HasAura("earth shield", ref->getSource(), false, true))
+                    {
+                        someoneHaveOwnerAura = true;
+                        break;
+                    }
+                }
+            }
+
+            return BuffOnTankTrigger::IsActive() && !someoneHaveOwnerAura;
+        }
     };
 }

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -486,17 +486,13 @@ namespace ai
 
         virtual bool IsActive()
         {
-            bool someoneHaveOwnerAura = false;
             Group* group = bot->GetGroup();
             if (group)
             {
                 for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
                 {
                     if (ai->HasAura("earth shield", ref->getSource(), false, true))
-                    {
-                        someoneHaveOwnerAura = true;
-                        break;
-                    }
+                        return false;
                 }
             }
 


### PR DESCRIPTION
Before
![obraz](https://github.com/celguar/mangosbot-bots/assets/28183654/93ae78f9-fa3f-48f0-9217-1d8719c28116)
After
![obraz](https://github.com/celguar/mangosbot-bots/assets/28183654/03bd5380-5068-4d49-8136-8ab8693ce386)
