### PR TITLE
- AoE fix: Bots now avoid aoe spell in tbc and wotlk

### DIFF
--- a/playerbot/strategy/values/NearestGameObjects.cpp
+++ b/playerbot/strategy/values/NearestGameObjects.cpp
@@ -76,11 +76,10 @@ list<ObjectGuid> NearestGameObjects::Calculate()
 list<ObjectGuid> NearestDynamicObjects::Calculate()
 {
     list<DynamicObject*> targets;
-#ifdef MANGOSBOT_ZERO
+
     AnyDynamicObjectInObjectRangeCheck u_check(bot, range);
     MaNGOS::DynamicObjectListSearcher<AnyDynamicObjectInObjectRangeCheck> searcher(targets, u_check);
     Cell::VisitAllObjects((const WorldObject*)bot, searcher, range);
-#endif
 
     list<ObjectGuid> result;
     for (list<DynamicObject*>::iterator tIter = targets.begin(); tIter != targets.end(); ++tIter)


### PR DESCRIPTION
![obraz](https://github.com/celguar/mangosbot-bots/assets/28183654/d9054389-254a-4ca6-b2eb-19cfe2c1bceb)
