### PR TITLE
Warrior rotation fix

### DIFF
--- a/playerbot/strategy/warrior/FuryWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/FuryWarriorStrategy.cpp
@@ -58,11 +58,11 @@ void FuryWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("bloodthirst", ACTION_NORMAL + 3), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "medium rage available",
+        "whirlwind",
         NextAction::array(0, new NextAction("whirlwind", ACTION_NORMAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "medium rage available",
+        "heroic strike",
         NextAction::array(0, new NextAction("heroic strike", ACTION_NORMAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
@@ -402,11 +402,11 @@ void FuryWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("bloodthirst", ACTION_NORMAL + 3), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "medium rage available",
+        "whirlwind",
         NextAction::array(0, new NextAction("whirlwind", ACTION_NORMAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "medium rage available",
+        "heroic strike",
         NextAction::array(0, new NextAction("heroic strike", ACTION_NORMAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
@@ -742,20 +742,20 @@ void FuryWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("slam", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "target critical health",
-        NextAction::array(0, new NextAction("execute", ACTION_NORMAL + 4), NULL)));
-
-    triggers.push_back(new TriggerNode(
         "bloodthirst",
-        NextAction::array(0, new NextAction("bloodthirst", ACTION_NORMAL + 3), NULL)));
+        NextAction::array(0, new NextAction("bloodthirst", ACTION_NORMAL + 4), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "medium rage available",
-        NextAction::array(0, new NextAction("whirlwind", ACTION_NORMAL + 2), NULL)));
+        "whirlwind",
+        NextAction::array(0, new NextAction("whirlwind", ACTION_NORMAL + 3), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "medium rage available",
-        NextAction::array(0, new NextAction("heroic strike", ACTION_NORMAL + 1), NULL)));
+        "heroic strike",
+        NextAction::array(0, new NextAction("heroic strike", ACTION_NORMAL + 2), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "target critical health",
+        NextAction::array(0, new NextAction("execute", ACTION_NORMAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "intercept on snare target",

--- a/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
@@ -109,6 +109,10 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
         NextAction::array(0, new NextAction("shield slam", ACTION_HIGH), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "bloodthirst",
+        NextAction::array(0, new NextAction("bloodthirst", ACTION_HIGH), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "high rage available",
         NextAction::array(0, new NextAction("heroic strike", ACTION_NORMAL + 2), NULL)));
 

--- a/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
@@ -220,6 +220,8 @@ namespace ai
                 creators["thunder clap on snare target"] = &TriggerFactoryInternal::thunder_clap_on_snare_target;
                 creators["thunder clap"] = &TriggerFactoryInternal::thunder_clap;
                 creators["bloodthirst"] = &TriggerFactoryInternal::bloodthirst;
+                creators["whirlwind"] = &TriggerFactoryInternal::whirlwind;
+                creators["heroic strike"] = &TriggerFactoryInternal::heroic_strike;
                 creators["berserker rage"] = &TriggerFactoryInternal::berserker_rage;
                 creators["pummel on enemy healer"] = &TriggerFactoryInternal::pummel_on_enemy_healer;
                 creators["pummel"] = &TriggerFactoryInternal::pummel;
@@ -258,6 +260,8 @@ namespace ai
             static Trigger* pummel_on_enemy_healer(PlayerbotAI* ai) { return new PummelInterruptEnemyHealerSpellTrigger(ai); }
             static Trigger* berserker_rage(PlayerbotAI* ai) { return new BerserkerRageBuffTrigger(ai); }
             static Trigger* bloodthirst(PlayerbotAI* ai) { return new BloodthirstBuffTrigger(ai); }
+            static Trigger* whirlwind(PlayerbotAI* ai) { return new WhirlwindTrigger(ai); }
+            static Trigger* heroic_strike(PlayerbotAI* ai) { return new HeroicStrikeTrigger(ai); }
             static Trigger* thunder_clap_on_snare_target(PlayerbotAI* ai) { return new ThunderClapSnareTrigger(ai); }
             static Trigger* thunder_clap(PlayerbotAI* ai) { return new ThunderClapTrigger(ai); }
             static Trigger* mortal_strike(PlayerbotAI* ai) { return new MortalStrikeDebuffTrigger(ai); }

--- a/playerbot/strategy/warrior/WarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/WarriorStrategy.cpp
@@ -34,7 +34,6 @@ public:
         */
 
         creators["berserker rage"] = &berserker_rage;
-        creators["whirlwind"] = &whirlwind;
     }
 
 private:
@@ -72,8 +71,6 @@ private:
     */
 
     ACTION_NODE_P(berserker_rage, "berserker rage", "berserker stance");
-
-    ACTION_NODE_A(whirlwind, "whirlwind", "cleave");
 };
 
 WarriorStrategy::WarriorStrategy(PlayerbotAI* ai) : ClassStrategy(ai)
@@ -172,16 +169,20 @@ void WarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 5), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "melee medium aoe",
+        NextAction::array(0, new NextAction("cleave", ACTION_HIGH + 4), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "thunder clap",
-        NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 4), NULL)));
+        NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 3), NULL)));
 
     triggers.push_back(new TriggerNode(
         "thunder clap on snare target",
-        NextAction::array(0, new NextAction("thunder clap on snare target", ACTION_HIGH + 3), NULL)));
+        NextAction::array(0, new NextAction("thunder clap on snare target", ACTION_HIGH + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "melee light aoe",
-        NextAction::array(0, new NextAction("demoralizing shout", ACTION_HIGH + 2), NULL)));
+        NextAction::array(0, new NextAction("demoralizing shout", ACTION_HIGH + 1), NULL)));
 }
 
 void WarriorAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -460,7 +461,11 @@ void WarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode(
         "melee medium aoe",
-        NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 3), NULL)));
+        NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 4), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "melee medium aoe",
+        NextAction::array(0, new NextAction("cleave", ACTION_HIGH + 3), NULL)));
 
     triggers.push_back(new TriggerNode(
         "thunder clap",
@@ -747,7 +752,11 @@ void WarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode(
         "melee medium aoe",
-        NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 3), NULL)));
+        NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 4), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "melee medium aoe",
+        NextAction::array(0, new NextAction("cleave", ACTION_HIGH + 3), NULL)));
 
     triggers.push_back(new TriggerNode(
         "thunder clap",

--- a/playerbot/strategy/warrior/WarriorTriggers.h
+++ b/playerbot/strategy/warrior/WarriorTriggers.h
@@ -80,30 +80,31 @@ namespace ai
         }
     };
 
-    class WhirlwindTrigger : public MediumRageAvailableTrigger
+    class WhirlwindTrigger : public SpellCanBeCastTrigger
     {
     public:
-        WhirlwindTrigger(PlayerbotAI* ai) : MediumRageAvailableTrigger(ai) {}
+        WhirlwindTrigger(PlayerbotAI* ai) : SpellCanBeCastTrigger(ai, "whirlwind") {}
         bool IsActive() override
         {
 #ifdef MANGOSBOT_TWO
-            return MediumRageAvailableTrigger::IsActive();
+            return SpellCanBeCastTrigger::IsActive();
 #else
-            return MediumRageAvailableTrigger::IsActive() && AI_VALUE2(uint8, "health", "current target") > 20;
+            return SpellCanBeCastTrigger::IsActive() && AI_VALUE2(uint8, "health", "current target") > 20;
 #endif
         }
     };
 
-    class HeroicStrikeTrigger : public MediumRageAvailableTrigger
+    class HeroicStrikeTrigger : public SpellCanBeCastTrigger
     {
     public:
-        HeroicStrikeTrigger(PlayerbotAI* ai) : MediumRageAvailableTrigger(ai) {}
+        HeroicStrikeTrigger(PlayerbotAI* ai) : SpellCanBeCastTrigger(ai, "heroic strike") {}
         bool IsActive() override
         {
 #ifdef MANGOSBOT_TWO
-            return MediumRageAvailableTrigger::IsActive();
+            return SpellCanBeCastTrigger::IsActive();
 #else
-            return MediumRageAvailableTrigger::IsActive() 
+            return SpellCanBeCastTrigger::IsActive() 
+                && AI_VALUE2(uint8, "rage", "self target") >= 50
                 && (AI_VALUE2(uint8, "health", "current target") > 20 || ai->IsTank(bot));
 #endif
         }

--- a/playerbot/strategy/warrior/WarriorTriggers.h
+++ b/playerbot/strategy/warrior/WarriorTriggers.h
@@ -34,7 +34,6 @@ namespace ai
     DEBUFF_TRIGGER(ShockwaveTrigger, "shockwave");
     BOOST_TRIGGER(DeathWishTrigger, "death wish");
     BOOST_TRIGGER(RecklessnessTrigger, "recklessness");
-    BUFF_TRIGGER(BloodthirstBuffTrigger, "bloodthirst");
     INTERRUPT_HEALER_TRIGGER(ShieldBashInterruptEnemyHealerSpellTrigger, "shield bash");
     INTERRUPT_TRIGGER(ShieldBashInterruptSpellTrigger, "shield bash");
     INTERRUPT_HEALER_TRIGGER(PummelInterruptEnemyHealerSpellTrigger, "pummel");
@@ -60,6 +59,53 @@ namespace ai
             }
 
             return false;
+        }
+    };
+
+    class BloodthirstBuffTrigger : public BuffTrigger
+    {
+    public:
+        BloodthirstBuffTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "bloodthirst") {}
+        bool IsActive() override
+        {
+#ifdef MANGOSBOT_ZERO
+            return BuffTrigger::IsActive() && (AI_VALUE2(uint8, "health", "current target") > 20 || ai->IsTank(bot));
+#elif MANGOSBOT_ONE
+            return BuffTrigger::IsActive() 
+                && (AI_VALUE2(uint8, "health", "current target") > 20 || AI_VALUE2(uint8, "rage", "self target") >= 40);
+#else
+            return BuffTrigger::IsActive();
+#endif
+
+        }
+    };
+
+    class WhirlwindTrigger : public MediumRageAvailableTrigger
+    {
+    public:
+        WhirlwindTrigger(PlayerbotAI* ai) : MediumRageAvailableTrigger(ai) {}
+        bool IsActive() override
+        {
+#ifdef MANGOSBOT_TWO
+            return MediumRageAvailableTrigger::IsActive();
+#else
+            return MediumRageAvailableTrigger::IsActive() && AI_VALUE2(uint8, "health", "current target") > 20;
+#endif
+        }
+    };
+
+    class HeroicStrikeTrigger : public MediumRageAvailableTrigger
+    {
+    public:
+        HeroicStrikeTrigger(PlayerbotAI* ai) : MediumRageAvailableTrigger(ai) {}
+        bool IsActive() override
+        {
+#ifdef MANGOSBOT_TWO
+            return MediumRageAvailableTrigger::IsActive();
+#else
+            return MediumRageAvailableTrigger::IsActive() 
+                && (AI_VALUE2(uint8, "health", "current target") > 20 || ai->IsTank(bot));
+#endif
         }
     };
 }


### PR DESCRIPTION
- Warrior: Bots no longer cast cleave in single target fight
- Warrior: Bots no longer prioritize execute in wotlk
- Warrior: Bots now prioritize execute in vanilla/tbc
- Warrior: Bots no longer wait for 40 rage to cast whirlwind
- Warrior: Bots no longer cast heroic strike below 50 rage