### PR TITLE
-Druid: Restro druid now cast lifebloom when get clearcasting in wotlk

### DIFF
--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -349,6 +349,7 @@ namespace ai
                 creators["rebirth on party"] = &TriggerFactoryInternal::rebirth_on_party;
                 creators["innervate self"] = &TriggerFactoryInternal::innervate_self;
                 creators["lifebloom"] = &TriggerFactoryInternal::lifebloom;
+                creators["clearcasting"] = &TriggerFactoryInternal::clearcasting;
             }
 
         private:
@@ -395,6 +396,7 @@ namespace ai
             static Trigger* rebirth_on_party(PlayerbotAI* ai) { return new RebirthOnPartyTrigger(ai); }
             static Trigger* innervate_self(PlayerbotAI* ai) { return new InnervateSelfTrigger(ai); }
             static Trigger* lifebloom(PlayerbotAI* ai) { return new LifebloomTankTrigger(ai); }
+            static Trigger* clearcasting(PlayerbotAI* ai) { return new ClearcastingTrigger(ai); }
         };
 
         class AiObjectContextInternal : public NamedObjectContext<Action>

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -407,4 +407,10 @@ namespace ai
                 && !target->getAttackers().empty();                                     //target have attackers
         }
     };
+
+    class ClearcastingTrigger : public HasAuraTrigger
+    {
+    public:
+        ClearcastingTrigger(PlayerbotAI* ai) : HasAuraTrigger(ai, "clearcasting") {}
+    };
 }

--- a/playerbot/strategy/druid/RestorationDruidStrategy.cpp
+++ b/playerbot/strategy/druid/RestorationDruidStrategy.cpp
@@ -818,6 +818,10 @@ void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigg
                              new NextAction("healing touch on party", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "clearcasting",
+        NextAction::array(0, new NextAction("lifebloom", ACTION_CRITICAL_HEAL - 1), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "low health",
         NextAction::array(0, new NextAction("regrowth", ACTION_MEDIUM_HEAL), NULL)));
 


### PR DESCRIPTION
![obraz](https://github.com/celguar/mangosbot-bots/assets/28183654/5b395e65-25f9-4fa8-8bea-1170bd632453)
