### PR TITLE
Remove follow strategy on load (prevents bots left in one city to rus…

### DIFF
--- a/playerbot/PlayerbotDbStore.cpp
+++ b/playerbot/PlayerbotDbStore.cpp
@@ -40,6 +40,9 @@ void PlayerbotDbStore::Load(PlayerbotAI *ai)
         } while (results->NextRow());
 
         ai->GetAiObjectContext()->Load(values);
+        
+        ai->ChangeStrategy("-passive,-follow,+stay", BotState::BOT_STATE_COMBAT);
+        ai->ChangeStrategy("-passive,-follow,+stay", BotState::BOT_STATE_NON_COMBAT);        
     }
 }
 


### PR DESCRIPTION
You left alts somewhere... Then login with another one, bring alts as bots - they start to move towards the new master (e.g., fly to a different continent). Let them do them only if necessary by doing `follow` command