### PR TITLE
Ignore loot list (backport from 2021-2022)

### DIFF
--- a/playerbot/LootObjectStack.cpp
+++ b/playerbot/LootObjectStack.cpp
@@ -119,6 +119,9 @@ void LootObject::Refresh(Player* bot, ObjectGuid guid)
             return;
 
         uint32 goId = go->GetGOInfo()->id;
+        set<uint32>& skipGoLootList = ai->GetAiObjectContext()->GetValue<set<uint32>& >("skip go loot list")->Get();
+        if (skipGoLootList.find(goId) != skipGoLootList.end()) return;
+
         uint32 lockId = go->GetGOInfo()->GetLockId();
         LockEntry const *lockInfo = sLockStore.LookupEntry(lockId);
         if (!lockInfo)

--- a/playerbot/strategy/actions/LootAction.cpp
+++ b/playerbot/strategy/actions/LootAction.cpp
@@ -381,6 +381,10 @@ bool StoreLootAction::IsLootAllowed(ItemQualifier& itemQualifier, PlayerbotAI *a
     if (lootItems.find(itemQualifier.GetId()) != lootItems.end())
         return true;
 
+    set<uint32>& skipItems = AI_VALUE(set<uint32>&, "skip loot list");
+    if (skipItems.find(itemQualifier.GetId()) != skipItems.end())
+        return false;
+
     uint32 max = proto->MaxCount;
     if (max > 0 && ai->GetBot()->HasItemCount(itemQualifier.GetId(), max, true))
         return false;

--- a/playerbot/strategy/actions/LootStrategyAction.cpp
+++ b/playerbot/strategy/actions/LootStrategyAction.cpp
@@ -15,6 +15,7 @@ bool LootStrategyAction::Execute(Event& event)
 
     LootObjectStack* lootItems = AI_VALUE(LootObjectStack*, "available loot");
     set<uint32>& alwaysLootItems = AI_VALUE(set<uint32>&, "always loot list");
+    set<uint32>& skipLootItems = AI_VALUE(set<uint32>&, "skip loot list");
 
     if (strategy == "?")
     {
@@ -25,23 +26,16 @@ bool LootStrategyAction::Execute(Event& event)
             ai->TellPlayer(requester, out);
         }
 
-        {
-            ostringstream out;
-            out << "Always loot items: ";
-            for (set<uint32>::iterator i = alwaysLootItems.begin(); i != alwaysLootItems.end(); i++)
-            {
-                ItemPrototype const *proto = sItemStorage.LookupEntry<ItemPrototype>(*i);
-                if (!proto)
-                {
-                    continue;
-                }
-
-                out << chat->formatItem(proto);
-            }
-
-            ai->TellPlayer(requester, out);
-        }
+        TellLootList(requester, "always loot list");
+        TellLootList(requester, "skip loot list");
     }
+    else if (strategy == "clear")
+    {
+        alwaysLootItems.clear();
+        skipLootItems.clear();
+        ai->TellPlayer(requester, "My loot list is now empty");
+        return true;
+    }    
     else
     {
         set<string> itemQualifiers = chat->parseItemQualifiers(strategy);
@@ -58,11 +52,15 @@ bool LootStrategyAction::Execute(Event& event)
             return true;
         }
 
+        bool ignore = strategy.size() > 1 && strategy.substr(0, 1) == "!";
         bool remove = strategy.size() > 1 && strategy.substr(0, 1) == "-";
         bool query = strategy.size() > 1 && strategy.substr(0, 1) == "?";
+        bool add = !ignore && !remove && !query;
+        bool changes = false;
         for (auto& qualifier : itemQualifiers)
         {
             ItemQualifier itemQualifier(qualifier);
+            auto itemid = itemQualifier.GetId();
             if (query)
             {
                 if (itemQualifier.GetProto())
@@ -72,20 +70,38 @@ bool LootStrategyAction::Execute(Event& event)
                     ai->TellPlayer(requester, out.str());
                 }
             }
-            else if (remove)
+            
+            if (remove || add)
             {
-                set<uint32>::iterator j = alwaysLootItems.find(itemQualifier.GetId());
-                if (j != alwaysLootItems.end())
-                {
-                    alwaysLootItems.erase(j);
-                }
-
-                ai->TellPlayer(requester, "Item(s) removed from always loot list");
+                set<uint32>::iterator j = skipLootItems.find(itemid);
+                if (j != skipLootItems.end()) skipLootItems.erase(j);
+                changes = true;
             }
-            else
+            
+            if (remove || ignore)
             {
-                alwaysLootItems.insert(itemQualifier.GetId());
-                ai->TellPlayer(requester, "Item(s) added to always loot list");
+                set<uint32>::iterator j = alwaysLootItems.find(itemid);
+                if (j != alwaysLootItems.end()) alwaysLootItems.erase(j);
+                changes = true;
+            }
+            
+            if (ignore)
+            {
+                skipLootItems.insert(itemid);
+                changes = true;
+            }
+
+            if (add)
+            {
+                alwaysLootItems.insert(itemid);
+                changes = true;
+            }
+
+            if (changes)
+            {
+                TellLootList(requester, "always loot list");
+                TellLootList(requester, "skip loot list");
+                AI_VALUE(LootObjectStack*, "available loot")->Clear();
             }
         }
     }
@@ -93,3 +109,22 @@ bool LootStrategyAction::Execute(Event& event)
     return true;
 }
 
+void LootStrategyAction::TellLootList(Player* requester, const string& name)
+{
+    set<uint32>& alwaysLootItems = AI_VALUE(set<uint32>&, name);
+    ostringstream out;
+    out << "My " << name << ":";
+
+    for (set<uint32>::iterator i = alwaysLootItems.begin(); i != alwaysLootItems.end(); i++)
+    {
+        ItemPrototype const *proto = sItemStorage.LookupEntry<ItemPrototype>(*i);
+        if (!proto)
+        {
+            continue;
+        }
+
+        out << " " << chat->formatItem(proto);
+    }
+    
+    ai->TellPlayer(requester, out);
+}

--- a/playerbot/strategy/actions/LootStrategyAction.cpp
+++ b/playerbot/strategy/actions/LootStrategyAction.cpp
@@ -16,6 +16,7 @@ bool LootStrategyAction::Execute(Event& event)
     LootObjectStack* lootItems = AI_VALUE(LootObjectStack*, "available loot");
     set<uint32>& alwaysLootItems = AI_VALUE(set<uint32>&, "always loot list");
     set<uint32>& skipLootItems = AI_VALUE(set<uint32>&, "skip loot list");
+    set<uint32>& skipGoLootList = AI_VALUE(set<uint32>&, "skip go loot list");
 
     if (strategy == "?")
     {
@@ -28,6 +29,7 @@ bool LootStrategyAction::Execute(Event& event)
 
         TellLootList(requester, "always loot list");
         TellLootList(requester, "skip loot list");
+        TellGoList(requester, "skip go loot list");
     }
     else if (strategy == "clear")
     {
@@ -39,8 +41,9 @@ bool LootStrategyAction::Execute(Event& event)
     else
     {
         set<string> itemQualifiers = chat->parseItemQualifiers(strategy);
+        list<ObjectGuid> gos = chat->parseGameobjects(strategy);
 
-        if (itemQualifiers.size() == 0)
+        if (itemQualifiers.size() == 0 && gos.size() == 0)
         {
             SET_AI_VALUE(string, "loot strategy", strategy);
 
@@ -96,13 +99,34 @@ bool LootStrategyAction::Execute(Event& event)
                 alwaysLootItems.insert(itemid);
                 changes = true;
             }
+        }
+            
+        for (list<ObjectGuid>::iterator i = gos.begin(); i != gos.end(); ++i)
+        {
+            GameObject *go = ai->GetGameObject(*i);
+            if (!go) continue;
+            uint32 goId = go->GetGOInfo()->id;
 
-            if (changes)
+            if (remove || add)
             {
-                TellLootList(requester, "always loot list");
-                TellLootList(requester, "skip loot list");
-                AI_VALUE(LootObjectStack*, "available loot")->Clear();
+                set<uint32>::iterator j = skipGoLootList.find(goId);
+                if (j != skipGoLootList.end()) skipGoLootList.erase(j);
+                changes = true;
             }
+
+            if (ignore)
+            {
+                skipGoLootList.insert(goId);
+                changes = true;
+            }
+        }
+
+        if (changes)
+        {
+            TellLootList(requester, "always loot list");
+            TellLootList(requester, "skip loot list");
+            TellGoList(requester, "skip go loot list");
+            AI_VALUE(LootObjectStack*, "available loot")->Clear();
         }
     }
 
@@ -126,5 +150,23 @@ void LootStrategyAction::TellLootList(Player* requester, const string& name)
         out << " " << chat->formatItem(proto);
     }
     
+    ai->TellPlayer(requester, out);
+}
+
+void LootStrategyAction::TellGoList(Player* requester, const string& name)
+{
+    set<uint32>& skipGoItems = AI_VALUE(set<uint32>&, name);
+    ostringstream out;
+    out << "My " << name << ":";
+
+    for (set<uint32>::iterator i = skipGoItems.begin(); i != skipGoItems.end(); i++)
+    {
+        uint32 id = *i;
+        GameObjectInfo const *proto = sGOStorage.LookupEntry<GameObjectInfo>(id);
+        if (!proto)
+            continue;
+
+        out << " |cFFFFFF00|Hfound:" << 0 << ":" << id << ":" <<  "|h[" << proto->name << "]|h|r";
+    }
     ai->TellPlayer(requester, out);
 }

--- a/playerbot/strategy/actions/LootStrategyAction.h
+++ b/playerbot/strategy/actions/LootStrategyAction.h
@@ -9,5 +9,8 @@ namespace ai
     public:
         LootStrategyAction(PlayerbotAI* ai) : ChatCommandAction(ai, "ll") {}
         virtual bool Execute(Event& event) override;
+
+    private:
+        void TellLootList(Player* requester, const string& name);
     };
 }

--- a/playerbot/strategy/actions/LootStrategyAction.h
+++ b/playerbot/strategy/actions/LootStrategyAction.h
@@ -12,5 +12,6 @@ namespace ai
 
     private:
         void TellLootList(Player* requester, const string& name);
+        void TellGoList(Player* requester, const string& name);
     };
 }

--- a/playerbot/strategy/values/ValueContext.h
+++ b/playerbot/strategy/values/ValueContext.h
@@ -183,6 +183,7 @@ namespace ai
             creators["stack space for item"] = &ValueContext::stack_space_for_item;
             creators["should loot object"] = &ValueContext::should_loot_object;
             creators["always loot list"] = &ValueContext::always_loot_list;
+            creators["skip loot list"] = &ValueContext::skip_loot_list;
             creators["loot strategy"] = &ValueContext::loot_strategy;
             creators["active rolls"] = &ValueContext::active_rolls;
             creators["last movement"] = &ValueContext::last_movement;
@@ -456,7 +457,8 @@ namespace ai
         static UntypedValue* has_available_loot(PlayerbotAI* ai) { return new HasAvailableLootValue(ai); }
         static UntypedValue* stack_space_for_item(PlayerbotAI* ai) { return new StackSpaceForItem(ai); }
         static UntypedValue* should_loot_object(PlayerbotAI* ai) { return new ShouldLootObject(ai); }
-        static UntypedValue* always_loot_list(PlayerbotAI* ai) { return new AlwaysLootListValue(ai); }
+        static UntypedValue* always_loot_list(PlayerbotAI* ai) { return new AlwaysLootListValue(ai, "always loot list"); }
+        static UntypedValue* skip_loot_list(PlayerbotAI* ai) { return new AlwaysLootListValue(ai, "skip loot list"); }
         static UntypedValue* loot_strategy(PlayerbotAI* ai) { return new LootStrategyValue(ai); }
         static UntypedValue* active_rolls(PlayerbotAI* ai) { return new ActiveRolls(ai); }
         

--- a/playerbot/strategy/values/ValueContext.h
+++ b/playerbot/strategy/values/ValueContext.h
@@ -184,6 +184,7 @@ namespace ai
             creators["should loot object"] = &ValueContext::should_loot_object;
             creators["always loot list"] = &ValueContext::always_loot_list;
             creators["skip loot list"] = &ValueContext::skip_loot_list;
+            creators["skip go loot list"] = &ValueContext::skip_go_loot_list;
             creators["loot strategy"] = &ValueContext::loot_strategy;
             creators["active rolls"] = &ValueContext::active_rolls;
             creators["last movement"] = &ValueContext::last_movement;
@@ -459,6 +460,7 @@ namespace ai
         static UntypedValue* should_loot_object(PlayerbotAI* ai) { return new ShouldLootObject(ai); }
         static UntypedValue* always_loot_list(PlayerbotAI* ai) { return new AlwaysLootListValue(ai, "always loot list"); }
         static UntypedValue* skip_loot_list(PlayerbotAI* ai) { return new AlwaysLootListValue(ai, "skip loot list"); }
+        static UntypedValue* skip_go_loot_list(PlayerbotAI* ai) { return new AlwaysLootListValue(ai, "skip go loot list"); }
         static UntypedValue* loot_strategy(PlayerbotAI* ai) { return new LootStrategyValue(ai); }
         static UntypedValue* active_rolls(PlayerbotAI* ai) { return new ActiveRolls(ai); }
         


### PR DESCRIPTION
Make bot ignore items or gos when looting:

ll +[item] = always loot item
ll ![item] = ignore item (do not loot it)
ll ![go] = ignore game object
ll -[item] = remove from lists
ll -[go] = remove from lists

(ll +[go] is not supported yet)