### PR TITLE
Removed substrategies reset after bot is loaded from DB

### DIFF
--- a/playerbot/strategy/values/SubStrategyValue.cpp
+++ b/playerbot/strategy/values/SubStrategyValue.cpp
@@ -49,3 +49,10 @@ void SubStrategyValue::SetValues(string& currentValue, const string newValue, co
 	if(!currentValues.empty())
 		currentValue.pop_back();
 }
+
+bool SubStrategyValue::Load(string value)
+{
+    this->value = "";
+    Set(value);
+    return true;
+}

--- a/playerbot/strategy/values/SubStrategyValue.h
+++ b/playerbot/strategy/values/SubStrategyValue.h
@@ -13,7 +13,7 @@ namespace ai
         virtual vector<string> GetAllowedValues() { return StrSplit(allowedValues, ","); }
 
         virtual string Save() override { return value; };
-        virtual bool Load(string value) override { Set(value); return true; };
+        virtual bool Load(string value) override;
     private:
         string allowedValues;
     };


### PR DESCRIPTION
I.e., I remove `ll -disenchant,-vendor`, and save the character. the DB has `loot strategy>equip,quest,skill,use` - this is correct.
Then it loads it back using `virtual bool Load(string value) override { Set(value); return true; };`
`SubStrategyValue::Set()` treats this value as `+equip,+quest,+skill,+use` and adds those 4 strategies to the default ones, restoring `disenchant` and `vendor` .

I think Load() needs to be changed to replace the value: `virtual bool Load(string value) override { this->value = value; return true; };` - this fixes the problem.

Is there any other reason to call Set() on Load()? 