### PR TITLE
Missing call to ai->StopMoving() prevents bot to drink/eat 

### DIFF
--- a/playerbot/strategy/actions/UseItemAction.cpp
+++ b/playerbot/strategy/actions/UseItemAction.cpp
@@ -339,6 +339,7 @@ bool UseItemAction::UseItemAuto(Player* requester, Item* item)
 
         bot->addUnitState(UNIT_STAND_STATE_SIT);
         ai->InterruptSpell();
+        ai->StopMoving();
 
         float hp = bot->GetHealthPercent();
         float mp = bot->GetPower(POWER_MANA) * 100.0f / bot->GetMaxPower(POWER_MANA);


### PR DESCRIPTION
if item cheat is disabled. 