### PR TITLE
Hunter melee fix

### DIFF
--- a/playerbot/strategy/actions/SayAction.cpp
+++ b/playerbot/strategy/actions/SayAction.cpp
@@ -8,6 +8,17 @@
 
 using namespace ai;
 
+unordered_set<string> noReplyMsgs = {
+  "join", "leave", "follow", "attack", "pull", "flee", "reset", "reset ai",
+  "all ?", "talents", "talents list", "talents auto", "talk", "stay", "stats",
+  "who", "items", "leave", "join", "repair", "summon", "nc ?", "co ?", "de ?",
+  "dead ?", "follow", "los", "guard", "do accept invitation", "stats", "react ?",
+  "reset strats", "home",
+};
+unordered_set<string> noReplyMsgParts = { "+", "-","@" , "follow target", "focus heal", "cast ", "accept [", "e [", "destroy [", "go zone" };
+
+unordered_set<string> noReplyMsgStarts = { "e ", "accept ", "cast ", "destroy " };
+
 SayAction::SayAction(PlayerbotAI* ai) : Action(ai, "say"), Qualified()
 {
 }
@@ -111,6 +122,33 @@ void ChatReplyAction::ChatReplyDo(Player* bot, uint32 type, uint32 guid1, uint32
 {
     ChatReplyType replyType = REPLY_NOT_UNDERSTAND; // default not understand
     std::string respondsText = "";
+
+    // if we're just commanding bots around, don't respond...
+    // first one is for exact word matches
+    if (noReplyMsgs.find(msg) != noReplyMsgs.end()) {
+        //ostringstream out;
+        //out << "DEBUG ChatReplyDo decided to ignore exact blocklist match" << msg;
+        //bot->Say(out.str(), LANG_UNIVERSAL);
+        return;
+    }
+
+    // second one is for partial matches like + or - where we change strats
+    if (std::any_of(noReplyMsgParts.begin(), noReplyMsgParts.end(), [&msg](const std::string& part) { return msg.find(part) != std::string::npos; })) {
+        //ostringstream out;
+        //out << "DEBUG ChatReplyDo decided to ignore partial blocklist match" << msg;
+        //bot->Say(out.str(), LANG_UNIVERSAL);
+
+        return;
+    }
+
+    if (std::any_of(noReplyMsgStarts.begin(), noReplyMsgStarts.end(), [&msg](const std::string& start) {
+        return msg.find(start) == 0;  // Check if the start matches the beginning of msg
+        })) {
+        //ostringstream out;
+        //out << "DEBUG ChatReplyDo decided to ignore start blocklist match" << msg;
+        //bot->Say(out.str(), LANG_UNIVERSAL);
+        return;
+    }
 
     // Chat Logic
     int32 verb_pos = -1;

--- a/playerbot/strategy/hunter/HunterStrategy.cpp
+++ b/playerbot/strategy/hunter/HunterStrategy.cpp
@@ -65,6 +65,10 @@ void HunterStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
     */
 
     triggers.push_back(new TriggerNode(
+        "enemy is close",
+        NextAction::array(0, new NextAction("select new target", ACTION_NORMAL + 1), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "counterattack",
         NextAction::array(0, new NextAction("counterattack", ACTION_HIGH + 2), NULL)));
 
@@ -448,9 +452,9 @@ void HunterStingRaidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigge
 
 void HunterAspectStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 {
-    triggers.push_back(new TriggerNode(
-        "target of attacker close",
-        NextAction::array(0, new NextAction("aspect of the monkey", ACTION_EMERGENCY), NULL)));
+//    triggers.push_back(new TriggerNode(
+//        "target of attacker close",
+//        NextAction::array(0, new NextAction("aspect of the monkey", ACTION_EMERGENCY), NULL)));
 
     triggers.push_back(new TriggerNode(
         "aspect of the hawk",


### PR DESCRIPTION
Added "select new target" to hunter actions when enemy is close, this fixes them being unable to switch to melee.
Disabled aspect of the monkey, since it's a waste of time and mana most of the time the bots uses it.