### PR TITLE
Fix annoying typo with empty s command

### DIFF
--- a/playerbot/strategy/actions/SellAction.cpp
+++ b/playerbot/strategy/actions/SellAction.cpp
@@ -30,7 +30,7 @@ bool SellAction::Execute(Event& event)
 
     string text = event.getParam();
 
-    if (text == "*")
+    if (text == "*" || text.empty())
         text = "gray";
 
     list<Item*> items = ai->InventoryParseItems(text, IterateItemsMask::ITERATE_ITEMS_IN_BAGS);


### PR DESCRIPTION
Change empty sell command to sell gray items instead of white (prevent selling all items by mistake)