### PR TITLE
Fixed Mage Logic - TBC

### DIFF
--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -183,6 +183,7 @@ namespace ai
     public:
         IceLanceTrigger(PlayerbotAI* ai) : Trigger(ai, "ice lance") {}
         bool IsActive() override;
+        string GetTargetName() override { return "current target"; }
     };
 
     BUFF_TRIGGER(MirrorImageTrigger, "mirror image");


### PR DESCRIPTION
Fixed Ice Lance logic.

Changed check to current target instead of self target.