### PR TITLE
ConfirmQuestAction: bots will answer to "<player> starts <quest>, do …

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -162,6 +162,7 @@ PlayerbotAI::PlayerbotAI(Player* bot) :
     masterIncomingPacketHandlers.AddHandler(CMSG_QUESTGIVER_HELLO, "gossip hello");
     masterIncomingPacketHandlers.AddHandler(CMSG_QUESTGIVER_COMPLETE_QUEST, "complete quest");
     masterIncomingPacketHandlers.AddHandler(CMSG_QUESTGIVER_ACCEPT_QUEST, "accept quest");
+    masterIncomingPacketHandlers.AddHandler(CMSG_QUEST_CONFIRM_ACCEPT, "confirm quest");
     masterIncomingPacketHandlers.AddHandler(CMSG_ACTIVATETAXI, "activate taxi");
     masterIncomingPacketHandlers.AddHandler(CMSG_ACTIVATETAXIEXPRESS, "activate taxi");
     masterIncomingPacketHandlers.AddHandler(CMSG_TAXICLEARALLNODES, "taxi done");
@@ -200,6 +201,7 @@ PlayerbotAI::PlayerbotAI(Player* bot) :
     botOutgoingPacketHandlers.AddHandler(SMSG_LOOT_START_ROLL, "loot start roll", true);
     botOutgoingPacketHandlers.AddHandler(SMSG_SUMMON_REQUEST, "summon request");
     botOutgoingPacketHandlers.AddHandler(MSG_RAID_READY_CHECK, "ready check");
+    botOutgoingPacketHandlers.AddHandler(SMSG_QUEST_CONFIRM_ACCEPT, "confirm quest");
 
     
 #ifndef MANGOSBOT_ZERO

--- a/playerbot/strategy/actions/AcceptQuestAction.cpp
+++ b/playerbot/strategy/actions/AcceptQuestAction.cpp
@@ -146,3 +146,48 @@ bool AcceptQuestShareAction::Execute(Event& event)
 
     return false;
 }
+
+bool ConfirmQuestAction::Execute(Event& event)
+{
+    Player *bot = ai->GetBot();
+    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
+
+    WorldPacket& p = event.getPacket();
+    p.rpos(0);
+    uint32 quest;
+    p >> quest;
+    Quest const* qInfo = sObjectMgr.GetQuestTemplate(quest);
+
+    quest = qInfo->GetQuestId();
+    if( !bot->CanTakeQuest( qInfo, false ) )
+    {
+        // can't take quest
+        ai->TellError(requester, BOT_TEXT("quest_cant_take"));
+        return false;
+    }
+
+    if( bot->CanAddQuest( qInfo, false ) )
+    {
+        bot->AddQuest( qInfo, requester );
+
+        if( bot->CanCompleteQuest( quest ) )
+            bot->CompleteQuest( quest );
+
+        if( qInfo->GetSrcSpell() > 0 )
+        {
+            bot->CastSpell( bot, qInfo->GetSrcSpell(),
+#ifdef MANGOS
+                    true
+#endif
+#ifdef CMANGOS
+                    (uint32)0
+#endif
+            );
+        }
+
+        ai->TellPlayer(requester, BOT_TEXT("quest_accept"), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+        return true;
+    }
+
+    return false;
+}

--- a/playerbot/strategy/actions/AcceptQuestAction.h
+++ b/playerbot/strategy/actions/AcceptQuestAction.h
@@ -27,4 +27,10 @@ namespace ai
         AcceptQuestShareAction(PlayerbotAI* ai) : Action(ai, "accept quest share") {}
         virtual bool Execute(Event& event);
     };
+
+    class ConfirmQuestAction : public Action {
+    public:
+        ConfirmQuestAction(PlayerbotAI* ai) : Action(ai, "confirm quest") {}
+        virtual bool Execute(Event& event);
+    };
 }

--- a/playerbot/strategy/actions/WorldPacketActionContext.h
+++ b/playerbot/strategy/actions/WorldPacketActionContext.h
@@ -54,6 +54,7 @@ namespace ai
             creators["tell cannot equip"] = &WorldPacketActionContext::tell_cannot_equip;
             creators["talk to quest giver"] = &WorldPacketActionContext::turn_in_quest;
             creators["accept quest"] = &WorldPacketActionContext::accept_quest;
+            creators["confirm quest"] = &WorldPacketActionContext::confirm_quest;
             creators["accept all quests"] = &WorldPacketActionContext::accept_all_quests;
             creators["accept quest share"] = &WorldPacketActionContext::accept_quest_share;
             creators["loot start roll"] = &WorldPacketActionContext::loot_start_roll;
@@ -127,6 +128,7 @@ namespace ai
         static Action* tell_cannot_equip(PlayerbotAI* ai) { return new InventoryChangeFailureAction(ai); }
         static Action* turn_in_quest(PlayerbotAI* ai) { return new TalkToQuestGiverAction(ai); }
         static Action* accept_quest(PlayerbotAI* ai) { return new AcceptQuestAction(ai); }
+        static Action* confirm_quest(PlayerbotAI* ai) { return new ConfirmQuestAction(ai); }
         static Action* accept_all_quests(PlayerbotAI* ai) { return new AcceptAllQuestsAction(ai); }
         static Action* accept_quest_share(PlayerbotAI* ai) { return new AcceptQuestShareAction(ai); }
         static Action* loot_start_roll(PlayerbotAI* ai) { return (QueryItemUsageAction*)new LootStartRollAction(ai); }

--- a/playerbot/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/playerbot/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -16,6 +16,7 @@ WorldPacketHandlerStrategy::WorldPacketHandlerStrategy(PlayerbotAI* ai) : PassTr
     supported.push_back("random bot update");
     supported.push_back("inventory change failure");
     supported.push_back("bg status");
+    supported.push_back("confirm quest");
 }
 
 void WorldPacketHandlerStrategy::InitNonCombatTriggers(std::list<TriggerNode*> &triggers)

--- a/playerbot/strategy/triggers/WorldPacketTriggerContext.h
+++ b/playerbot/strategy/triggers/WorldPacketTriggerContext.h
@@ -19,6 +19,7 @@ namespace ai
             creators["use game object"] = &WorldPacketTriggerContext::use_game_object;
             creators["complete quest"] = &WorldPacketTriggerContext::complete_quest;
             creators["accept quest"] = &WorldPacketTriggerContext::accept_quest;
+            creators["confirm quest"] = &WorldPacketTriggerContext::confirm_quest;
             creators["quest share"] = &WorldPacketTriggerContext::quest_share;
             creators["loot start roll"] = &WorldPacketTriggerContext::loot_start_roll;
             creators["loot roll"] = &WorldPacketTriggerContext::loot_roll;
@@ -94,6 +95,7 @@ namespace ai
         static Trigger* use_game_object(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "use game object"); }
         static Trigger* complete_quest(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "complete quest"); }
         static Trigger* accept_quest(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "accept quest"); }
+        static Trigger* confirm_quest(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "confirm quest"); }
         static Trigger* quest_share(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest share"); }
         static Trigger* loot_start_roll(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "loot start roll"); }
         static Trigger* loot_roll(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "loot roll"); }


### PR DESCRIPTION
…you want to do it as well?"

Backport from old repo - enables bots to accept various quests, such as defending defias traitor, escorts, etc. previously ignored by bots.
When master (or other bot) starts the quest, the popup asks "<player> starts <quest>, do you want to do it as well?", then all bots in your party answer "Yes", effecively starting the quest.