### PR TITLE
Seed of Corruption AOE Strategy

### DIFF
--- a/playerbot/strategy/warlock/WarlockAiObjectContext.cpp
+++ b/playerbot/strategy/warlock/WarlockAiObjectContext.cpp
@@ -350,6 +350,7 @@ namespace ai
                 creators["no felguard"] = &TriggerFactoryInternal::no_felguard;
                 creators["spell lock"] = &TriggerFactoryInternal::spell_lock;
                 creators["spell lock enemy healer"] = &TriggerFactoryInternal::spell_lock_enemy_healer;
+                creators["seed of corruption on attacker"] = &TriggerFactoryInternal::seed_of_corruption_on_attacker;
             }
 
         private:
@@ -405,6 +406,7 @@ namespace ai
             static Trigger* no_felguard(PlayerbotAI* ai) { return new NoFelguardTrigger(ai); }
             static Trigger* spell_lock(PlayerbotAI* ai) { return new SpellLockTrigger(ai); }
             static Trigger* spell_lock_enemy_healer(PlayerbotAI* ai) { return new SpellLockEnemyHealerTrigger(ai); }
+            static Trigger* seed_of_corruption_on_attacker(PlayerbotAI* ai) { return new SeedOfCorruptionOnAttackerTrigger(ai); }
         };
 
         class AiObjectContextInternal : public NamedObjectContext<Action>

--- a/playerbot/strategy/warlock/WarlockStrategy.cpp
+++ b/playerbot/strategy/warlock/WarlockStrategy.cpp
@@ -625,16 +625,12 @@ void WarlockAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
     AoeStrategy::InitCombatTriggers(triggers);
 
     triggers.push_back(new TriggerNode(
-        "corruption on attacker",
+        "seed of corruption on attacker",
         NextAction::array(0, new NextAction("seed of corruption on attacker", ACTION_HIGH + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "corruption on attacker",
         NextAction::array(0, new NextAction("corruption on attacker", ACTION_HIGH + 1), NULL)));
-
-    triggers.push_back(new TriggerNode(
-        "ranged medium aoe",
-        NextAction::array(0, new NextAction("rain of fire", ACTION_HIGH), NULL)));
 }
 
 void WarlockAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -1077,7 +1073,7 @@ void WarlockAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
     AoeStrategy::InitCombatTriggers(triggers);
 
     triggers.push_back(new TriggerNode(
-        "corruption on attacker",
+        "seed of corruption on attacker",
         NextAction::array(0, new NextAction("seed of corruption on attacker", ACTION_HIGH + 2), NULL)));
 
     triggers.push_back(new TriggerNode(

--- a/playerbot/strategy/warlock/WarlockTriggers.cpp
+++ b/playerbot/strategy/warlock/WarlockTriggers.cpp
@@ -70,9 +70,20 @@ bool DrainSoulTrigger::IsActive()
 
 bool CorruptionOnAttackerTrigger::IsActive()
 {
-    Unit* target = GetTarget();
-    return target && target->IsAlive() && !ai->HasAura("corruption", target, false, true) && !ai->HasAura("seed of corruption", target, false, true);
+	Unit* target = GetTarget();
+	return target && target->IsAlive() && !ai->HasAura("corruption", target, false, true);
 }
+
+bool SeedOfCorruptionOnAttackerTrigger::IsActive()
+{
+	if (DebuffOnAttackerTrigger::IsActive())
+	{
+		return AI_VALUE(uint8, "attackers count") >= 4;
+	}
+
+	return false;
+}
+
 
 bool NoCurseTrigger::IsActive()
 {

--- a/playerbot/strategy/warlock/WarlockTriggers.h
+++ b/playerbot/strategy/warlock/WarlockTriggers.h
@@ -51,6 +51,13 @@ namespace ai
         bool IsActive() override;
     };
 
+    class SeedOfCorruptionOnAttackerTrigger : public DebuffOnAttackerTrigger
+    {
+    public:
+        SeedOfCorruptionOnAttackerTrigger(PlayerbotAI* ai) : DebuffOnAttackerTrigger(ai, "seed of corruption") {}
+        bool IsActive() override;
+    };
+
     DEBUFF_TRIGGER(CurseOfAgonyTrigger, "curse of agony");
 
     class CurseOfAgonyOnAttackerTrigger : public DebuffOnAttackerTrigger


### PR DESCRIPTION
Added new strategy that provides bot with target information. If bot has less than 4 targets the bot will ignore using Seed of Corruption. 4 or more targets the bot will use seed of corruption.